### PR TITLE
BRGD-63 Request Invoker

### DIFF
--- a/src/Models/Endpoint.cs
+++ b/src/Models/Endpoint.cs
@@ -1,4 +1,9 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
 using System.Net.Http;
+
+#pragma warning disable SA1649
 
 namespace Brighid.Discord.Models
 {
@@ -12,5 +17,45 @@ namespace Brighid.Discord.Models
         /// </summary>
         [ApiEndpoint(nameof(HttpMethod.Post), "/channels/{channel.id}/messages")]
         ChannelCreateMessage = 0,
+    }
+
+    /// <summary>
+    /// Extension methods for the Endpoint enum.
+    /// </summary>
+    /// <todo>Auto-generate these.</todo>
+    public static class EndpointExtensions
+    {
+        /// <summary>
+        /// Gets the endpoint information associated with the endpoint.
+        /// </summary>
+        /// <param name="endpoint">The endpoint to get info for.</param>
+        /// <returns>The associated ApiEndpointAttribute the endpoint was annotated with.</returns>
+        public static ApiEndpointAttribute? GetEndpointInfo(this Endpoint endpoint)
+        {
+            var memberInfo = typeof(Endpoint).GetMember(endpoint.ToString()).FirstOrDefault();
+            var attributes = from attr in memberInfo?.GetCustomAttributes(true) ?? Array.Empty<object>() where attr.GetType() == typeof(ApiEndpointAttribute) select attr;
+            var endpointInfo = (ApiEndpointAttribute?)attributes.FirstOrDefault();
+            return endpointInfo;
+        }
+
+        /// <summary>
+        /// Gets the HttpMethod of an enum.
+        /// </summary>
+        /// <param name="endpoint">The target endpoint.</param>
+        /// <returns>The corresponding HttpMethod to this endpoint.</returns>
+        public static HttpMethod GetMethod(this Endpoint endpoint)
+        {
+            var endpointInfo = endpoint.GetEndpointInfo();
+            return endpointInfo?.HttpMethod switch
+            {
+                nameof(HttpMethod.Post) => HttpMethod.Post,
+                nameof(HttpMethod.Get) => HttpMethod.Get,
+                nameof(HttpMethod.Delete) => HttpMethod.Delete,
+                nameof(HttpMethod.Put) => HttpMethod.Put,
+                nameof(HttpMethod.Patch) => HttpMethod.Patch,
+                nameof(HttpMethod.Head) => HttpMethod.Head,
+                _ => throw new InvalidEnumArgumentException(),
+            };
+        }
     }
 }

--- a/src/Models/Request.cs
+++ b/src/Models/Request.cs
@@ -9,27 +9,22 @@ namespace Brighid.Discord.Models
     /// <summary>
     /// Represents an API request to be made.
     /// </summary>
-    public struct Request
+    public class Request
     {
         /// <summary>
-        /// Initializes a new <see cref="Request" /> record.
+        /// Initializes a new <see cref="Request" /> class.
         /// </summary>
         /// <param name="endpoint">The endpoint to use for the request.</param>
         public Request(Endpoint endpoint)
         {
-            Id = Guid.NewGuid();
             Endpoint = endpoint;
-            RequestBody = null;
-            ResponseQueueURL = null;
-            Parameters = new Dictionary<string, string>();
-            Headers = new Dictionary<string, string>();
         }
 
         /// <summary>
         /// Gets or sets the request ID.
         /// </summary>
         [JsonPropertyName("id")]
-        public Guid Id { get; set; }
+        public Guid Id { get; set; } = Guid.NewGuid();
 
         /// <summary>
         /// Gets or sets the path template to build the URL from.
@@ -53,12 +48,12 @@ namespace Brighid.Discord.Models
         /// Gets or sets the request parameters to be used in the endpoint's path template.
         /// </summary>
         [JsonPropertyName("p")]
-        public Dictionary<string, string> Parameters { get; set; }
+        public Dictionary<string, string> Parameters { get; set; } = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the headers to be sent along with the request.
         /// </summary>
         [JsonPropertyName("h")]
-        public Dictionary<string, string> Headers { get; set; }
+        public Dictionary<string, string> Headers { get; set; } = new Dictionary<string, string>();
     }
 }

--- a/src/Models/Response.cs
+++ b/src/Models/Response.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Text.Json.Serialization;
 
 namespace Brighid.Discord.Models
@@ -15,9 +16,15 @@ namespace Brighid.Discord.Models
         public Guid RequestId { get; set; }
 
         /// <summary>
+        /// Gets or sets the response status code.
+        /// </summary>
+        [JsonPropertyName("s")]
+        public HttpStatusCode StatusCode { get; set; }
+
+        /// <summary>
         /// Gets or sets the response.
         /// </summary>
-        [JsonPropertyName("m")]
-        public string Message { get; set; }
+        [JsonPropertyName("b")]
+        public string? Body { get; set; }
     }
 }

--- a/src/RestQueue/Requests/Exceptions/IRequestMessageException.cs
+++ b/src/RestQueue/Requests/Exceptions/IRequestMessageException.cs
@@ -1,0 +1,13 @@
+namespace Brighid.Discord.RestQueue.Requests
+{
+    /// <summary>
+    /// An exception dealing with a Request Message.
+    /// </summary>
+    public interface IRequestMessageException
+    {
+        /// <summary>
+        /// Gets the request message associated with this exception.
+        /// </summary>
+        RequestMessage RequestMessage { get; init; }
+    }
+}

--- a/src/RestQueue/Requests/Exceptions/RequestMessageNotDeletedException.cs
+++ b/src/RestQueue/Requests/Exceptions/RequestMessageNotDeletedException.cs
@@ -12,7 +12,7 @@ namespace Brighid.Discord.RestQueue.Requests
         /// </summary>
         /// <param name="message">The request message that failed to delete.</param>
         public RequestMessageNotDeletedException(RequestMessage message)
-            : base($"Request {message.Request.Id} failed to delete in the queue.")
+            : base($"Request {message.RequestDetails.Id} failed to delete in the queue.")
         {
             RequestMessage = message;
         }

--- a/src/RestQueue/Requests/Exceptions/RequestMessageNotDeletedException.cs
+++ b/src/RestQueue/Requests/Exceptions/RequestMessageNotDeletedException.cs
@@ -5,21 +5,29 @@ namespace Brighid.Discord.RestQueue.Requests
     /// <summary>
     /// Exception that is thrown when a message fails to delete.
     /// </summary>
-    public class RequestMessageNotDeletedException : Exception
+    public class RequestMessageNotDeletedException : Exception, IRequestMessageException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestMessageNotDeletedException" /> class.
         /// </summary>
         /// <param name="message">The request message that failed to delete.</param>
         public RequestMessageNotDeletedException(RequestMessage message)
-            : base($"Request {message.RequestDetails.Id} failed to delete in the queue.")
         {
             RequestMessage = message;
         }
 
         /// <summary>
-        /// Gets or sets the message that failed to delete.
+        /// Initializes a new instance of the <see cref="RequestMessageNotDeletedException" /> class.
         /// </summary>
-        public RequestMessage RequestMessage { get; set; }
+        public RequestMessageNotDeletedException()
+        {
+            RequestMessage = null!;
+        }
+
+        /// <inheritdoc />
+        public override string Message => $"Request {RequestMessage?.RequestDetails?.Id} failed to delete in the queue.";
+
+        /// <inheritdoc />
+        public RequestMessage RequestMessage { get; init; }
     }
 }

--- a/src/RestQueue/Requests/Exceptions/VisibilityTimeoutNotUpdatedException.cs
+++ b/src/RestQueue/Requests/Exceptions/VisibilityTimeoutNotUpdatedException.cs
@@ -5,21 +5,29 @@ namespace Brighid.Discord.RestQueue.Requests
     /// <summary>
     /// Exception that is thrown when a message visibility timeout fails to update.
     /// </summary>
-    public class VisibilityTimeoutNotUpdatedException : Exception
+    public class VisibilityTimeoutNotUpdatedException : Exception, IRequestMessageException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="VisibilityTimeoutNotUpdatedException" /> class.
         /// </summary>
         /// <param name="message">The message that failed to update.</param>
         public VisibilityTimeoutNotUpdatedException(RequestMessage message)
-            : base($"Request {message.RequestDetails.Id}'s visibility timeout failed to update.")
         {
             RequestMessage = message;
         }
 
         /// <summary>
-        /// Gets or sets the message that failed to update.
+        /// Initializes a new instance of the <see cref="VisibilityTimeoutNotUpdatedException" /> class.
         /// </summary>
-        public RequestMessage RequestMessage { get; set; }
+        public VisibilityTimeoutNotUpdatedException()
+        {
+            RequestMessage = null!;
+        }
+
+        /// <inheritdoc />
+        public override string Message => $"Request {RequestMessage?.RequestDetails?.Id}'s visibility timeout failed to update.";
+
+        /// <inheritdoc />
+        public RequestMessage RequestMessage { get; init; }
     }
 }

--- a/src/RestQueue/Requests/Exceptions/VisibilityTimeoutNotUpdatedException.cs
+++ b/src/RestQueue/Requests/Exceptions/VisibilityTimeoutNotUpdatedException.cs
@@ -12,7 +12,7 @@ namespace Brighid.Discord.RestQueue.Requests
         /// </summary>
         /// <param name="message">The message that failed to update.</param>
         public VisibilityTimeoutNotUpdatedException(RequestMessage message)
-            : base($"Request {message.Request.Id}'s visibility timeout failed to update.")
+            : base($"Request {message.RequestDetails.Id}'s visibility timeout failed to update.")
         {
             RequestMessage = message;
         }

--- a/src/RestQueue/Requests/Extensions/RequestsServiceCollectionExtensions.cs
+++ b/src/RestQueue/Requests/Extensions/RequestsServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using System.Net.Http;
+
 using Brighid.Discord.RestQueue.Requests;
 
 using Microsoft.Extensions.Configuration;
@@ -19,6 +21,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Configure<RequestOptions>(configuration.GetSection("Requests"));
             services.AddSingleton<IUrlBuilder, DefaultUrlBuilder>();
             services.AddSingleton<IRequestMessageRelay, SqsRequestMessageRelay>();
+            services.AddSingleton<IRequestInvoker, DefaultRequestInvoker>();
+            services.AddSingleton<HttpMessageInvoker, HttpClient>();
         }
     }
 }

--- a/src/RestQueue/Requests/Extensions/RequestsServiceCollectionExtensions.cs
+++ b/src/RestQueue/Requests/Extensions/RequestsServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using Brighid.Discord.RestQueue.Requests;
 
 using Microsoft.Extensions.Configuration;
 
+using HttpClient = Brighid.Discord.RestQueue.Requests.HttpClient;
+
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>

--- a/src/RestQueue/Requests/Models/RequestMessage.cs
+++ b/src/RestQueue/Requests/Models/RequestMessage.cs
@@ -14,7 +14,7 @@ namespace Brighid.Discord.RestQueue.Requests
         /// <summary>
         /// Gets or sets the request details.
         /// </summary>
-        public Request RequestDetails { get; set; }
+        public Request RequestDetails { get; set; } = null!;
 
         /// <summary>
         /// Gets or sets the message receipt handle.

--- a/src/RestQueue/Requests/Models/RequestMessage.cs
+++ b/src/RestQueue/Requests/Models/RequestMessage.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,7 +14,7 @@ namespace Brighid.Discord.RestQueue.Requests
         /// <summary>
         /// Gets or sets the request details.
         /// </summary>
-        public Request Request { get; set; }
+        public Request RequestDetails { get; set; }
 
         /// <summary>
         /// Gets or sets the message receipt handle.
@@ -29,6 +30,11 @@ namespace Brighid.Discord.RestQueue.Requests
         /// Gets or sets the promise task that will complete when this task has finished processing.
         /// </summary>
         public TaskCompletionSource Promise { get; set; } = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Gets or sets the Request Message's response code.
+        /// </summary>
+        public HttpStatusCode ResponseCode { get; set; }
 
         /// <summary>
         /// Gets or sets the Request Message's response to send back to the requester when complete.

--- a/src/RestQueue/Requests/Models/RequestOptions.cs
+++ b/src/RestQueue/Requests/Models/RequestOptions.cs
@@ -13,6 +13,16 @@ namespace Brighid.Discord.RestQueue.Requests
         public Uri QueueUrl { get; set; } = new Uri("http://localhost");
 
         /// <summary>
+        /// Gets or sets the authentication scheme used when sending requests.
+        /// </summary>
+        public string AuthScheme { get; set; } = "Bot";
+
+        /// <summary>
+        /// Gets or sets the token used to authenticate requests with.
+        /// </summary>
+        public string Token { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets the number of seconds to buffer delete message requests for.
         /// </summary>
         public double MessageBufferPeriod { get; set; } = 30;

--- a/src/RestQueue/Requests/Services/DefaultRequestInvoker.cs
+++ b/src/RestQueue/Requests/Services/DefaultRequestInvoker.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Brighid.Discord.Models;
+
+using Microsoft.Extensions.Logging;
+
+namespace Brighid.Discord.RestQueue.Requests
+{
+    /// <inheritdoc />
+    public class DefaultRequestInvoker : IRequestInvoker
+    {
+        private readonly HttpMessageInvoker client;
+        private readonly IUrlBuilder urlBuilder;
+        private readonly IRequestMessageRelay relay;
+        private readonly ILogger<DefaultRequestInvoker> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultRequestInvoker" /> class.
+        /// </summary>
+        /// <param name="client">Client used to send/recieve http messages.</param>
+        /// <param name="urlBuilder">Builder used to build URLs from requests.</param>
+        /// <param name="relay">Service used to relay messages back and forth between SQS.</param>
+        /// <param name="logger">Logger used to log info to some destination(s).</param>
+        public DefaultRequestInvoker(
+            HttpMessageInvoker client,
+            IUrlBuilder urlBuilder,
+            IRequestMessageRelay relay,
+            ILogger<DefaultRequestInvoker> logger
+        )
+        {
+            this.client = client;
+            this.urlBuilder = urlBuilder;
+            this.relay = relay;
+            this.logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task Invoke(RequestMessage request, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var httpRequest = new HttpRequestMessage
+                {
+                    RequestUri = urlBuilder.BuildFromRequest(request.RequestDetails),
+                    Method = request.RequestDetails.Endpoint.GetMethod(),
+                    Content = CreateContent(request),
+                };
+
+                logger.LogInformation("Sending request uri:{@uri} method:{@method} body:{@body}", httpRequest.RequestUri, httpRequest.Method, httpRequest.Content);
+                var httpResponse = await client.SendAsync(httpRequest, cancellationToken);
+                var responseString = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
+                logger.LogInformation("Received response from {@uri}: {@response}", httpRequest.RequestUri, responseString);
+
+                await relay.Complete(request, httpResponse.StatusCode, responseString, cancellationToken);
+            }
+            catch (Exception exception)
+            {
+                logger.LogError("Error occurred while attempting to invoke request: {@exception}", exception);
+                await relay.Fail(request, 0, cancellationToken);
+            }
+        }
+
+        private static HttpContent? CreateContent(RequestMessage request)
+        {
+            if (request.RequestDetails.RequestBody == null)
+            {
+                return null;
+            }
+
+            var content = new StringContent(request.RequestDetails.RequestBody);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            return content;
+        }
+    }
+}

--- a/src/RestQueue/Requests/Services/DefaultUrlBuilder.cs
+++ b/src/RestQueue/Requests/Services/DefaultUrlBuilder.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 using Brighid.Discord.Models;
 
@@ -26,9 +25,7 @@ namespace Brighid.Discord.RestQueue.Requests
         /// <inheritdoc />
         public Uri BuildFromRequest(Request request)
         {
-            var memberInfo = typeof(Endpoint).GetMember(request.Endpoint.ToString()).FirstOrDefault();
-            var attributes = from attr in memberInfo?.GetCustomAttributes(true) ?? Array.Empty<object>() where attr.GetType() == typeof(ApiEndpointAttribute) select attr;
-            var endpointInfo = (ApiEndpointAttribute?)attributes.FirstOrDefault();
+            var endpointInfo = request.Endpoint.GetEndpointInfo();
             var result = string.Empty;
 
             if (endpointInfo?.Template == null)

--- a/src/RestQueue/Requests/Services/HttpClient.cs
+++ b/src/RestQueue/Requests/Services/HttpClient.cs
@@ -1,0 +1,31 @@
+using System.Net.Http.Headers;
+
+using Microsoft.Extensions.Options;
+
+namespace Brighid.Discord.RestQueue.Requests
+{
+    /// <summary>
+    /// Client used to make HTTP requests.
+    /// </summary>
+    public class HttpClient : System.Net.Http.HttpClient
+    {
+        private readonly RequestOptions options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpClient" /> class.
+        /// </summary>
+        /// <param name="options">Options to use for making HTTP requests.</param>
+        public HttpClient(
+            IOptions<RequestOptions> options
+        )
+        {
+            this.options = options.Value;
+            Configure();
+        }
+
+        private void Configure()
+        {
+            DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(options.AuthScheme, options.Token);
+        }
+    }
+}

--- a/src/RestQueue/Requests/Services/IRequestInvoker.cs
+++ b/src/RestQueue/Requests/Services/IRequestInvoker.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Brighid.Discord.RestQueue.Requests
+{
+    /// <summary>
+    /// Service that invokes requests.
+    /// </summary>
+    public interface IRequestInvoker
+    {
+        /// <summary>
+        /// Invokes the given <paramref name="request" />.
+        /// </summary>
+        /// <param name="request">The request to invoke.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The resulting task.</returns>
+        Task Invoke(RequestMessage request, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/RestQueue/Requests/Services/IRequestMessageRelay.cs
+++ b/src/RestQueue/Requests/Services/IRequestMessageRelay.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,10 +21,11 @@ namespace Brighid.Discord.RestQueue.Requests
         /// Complete a message by deleting it from the queue.
         /// </summary>
         /// <param name="message">Message to complete.</param>
+        /// <param name="statusCode">Status code to send back to the requester.</param>
         /// <param name="response">Response to send to the requester, or null if no response should be sent.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The resulting task.</returns>
-        Task Complete(RequestMessage message, string? response = null, CancellationToken cancellationToken = default);
+        Task Complete(RequestMessage message, HttpStatusCode statusCode, string? response = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Signals that a message failed to process.  The message will be marked as visible to other workers after <paramref name="visibilityTimeout" /> seconds.

--- a/src/RestQueue/Requests/Services/SqsRequestMessageRelay.cs
+++ b/src/RestQueue/Requests/Services/SqsRequestMessageRelay.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -66,11 +67,12 @@ namespace Brighid.Discord.RestQueue.Requests
         }
 
         /// <inheritdoc />
-        public async Task Complete(RequestMessage message, string? response = null, CancellationToken cancellationToken = default)
+        public async Task Complete(RequestMessage message, HttpStatusCode statusCode, string? response = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             message.State = RequestMessageState.Succeeded;
             message.CancellationToken = cancellationToken;
+            message.ResponseCode = statusCode;
             message.Response = response;
 
             await completeQueue.WaitToWrite(cancellationToken);
@@ -128,7 +130,7 @@ namespace Brighid.Discord.RestQueue.Requests
             try
             {
                 var request = await serializer.Deserialize<Request>(message.Body, cancellationToken);
-                return new RequestMessage { Request = request, ReceiptHandle = message.ReceiptHandle };
+                return new RequestMessage { RequestDetails = request, ReceiptHandle = message.ReceiptHandle };
             }
             catch (Exception exception)
             {
@@ -171,14 +173,14 @@ namespace Brighid.Discord.RestQueue.Requests
 
             try
             {
-                var entries = from message in messagesToDelete select new DeleteMessageBatchRequestEntry { Id = message.Request.Id.ToString(), ReceiptHandle = message.ReceiptHandle };
+                var entries = from message in messagesToDelete select new DeleteMessageBatchRequestEntry { Id = message.RequestDetails.Id.ToString(), ReceiptHandle = message.ReceiptHandle };
                 logger.LogInformation("Sending sqs:DeleteMessageBatch with {@count} entries", entries.Count());
 
                 var request = new DeleteMessageBatchRequest { QueueUrl = options.QueueUrl.ToString(), Entries = entries.ToList() };
                 var response = await sqs.DeleteMessageBatchAsync(request, workerCancellationToken);
                 logger.LogInformation("Received sqs:DeleteMessageBatch response: {@response}", response);
 
-                var messageDict = messagesToDelete.ToDictionary(message => message.Request.Id.ToString(), message => message);
+                var messageDict = messagesToDelete.ToDictionary(message => message.RequestDetails.Id.ToString(), message => message);
                 var failedMessageIds = from failedMessage in response.Failed select failedMessage.Id.ToString();
 
                 foreach (var failedMessageId in failedMessageIds)
@@ -216,7 +218,7 @@ namespace Brighid.Discord.RestQueue.Requests
                 var entries = from message in messagesToChange
                               select new ChangeMessageVisibilityBatchRequestEntry
                               {
-                                  Id = message.Request.Id.ToString(),
+                                  Id = message.RequestDetails.Id.ToString(),
                                   ReceiptHandle = message.ReceiptHandle,
                                   VisibilityTimeout = (int)message.VisibilityTimeout,
                               };
@@ -225,7 +227,7 @@ namespace Brighid.Discord.RestQueue.Requests
                 var response = await sqs.ChangeMessageVisibilityBatchAsync(options.QueueUrl.ToString(), entries.ToList(), workerCancellationToken);
                 logger.LogInformation("Received sqs:ChangeMessageVisibilityBatch response: {@response}", response);
 
-                var messageDict = messagesToChange.ToDictionary(message => message.Request.Id.ToString(), message => message);
+                var messageDict = messagesToChange.ToDictionary(message => message.RequestDetails.Id.ToString(), message => message);
                 var failedMessageIds = from failedMessage in response.Failed select failedMessage.Id.ToString();
 
                 foreach (var failedMessageId in failedMessageIds)
@@ -254,7 +256,7 @@ namespace Brighid.Discord.RestQueue.Requests
         {
             workerCancellationToken.ThrowIfCancellationRequested();
 
-            if (message.Response == null || message.Request.ResponseQueueURL == null)
+            if (message.Response == null || message.RequestDetails.ResponseQueueURL == null)
             {
                 message.Promise.TrySetResult();
                 return;
@@ -262,11 +264,11 @@ namespace Brighid.Discord.RestQueue.Requests
 
             try
             {
-                var response = new Response { RequestId = message.Request.Id, Message = message.Response };
+                var response = new Response { RequestId = message.RequestDetails.Id, StatusCode = message.ResponseCode, Body = message.Response };
                 var payload = await serializer.Serialize(response, workerCancellationToken);
 
                 logger.LogInformation("Sending sqs:SendMessage with message: {@message}", message);
-                var sendMessageResponse = await sqs.SendMessageAsync(message.Request.ResponseQueueURL.ToString(), payload, workerCancellationToken);
+                var sendMessageResponse = await sqs.SendMessageAsync(message.RequestDetails.ResponseQueueURL.ToString(), payload, workerCancellationToken);
                 logger.LogInformation("Received sqs:SendMessage response: {@response}", sendMessageResponse);
 
                 message.Promise.TrySetResult();

--- a/src/RestQueue/RestQueueHost.cs
+++ b/src/RestQueue/RestQueueHost.cs
@@ -42,11 +42,12 @@ namespace Brighid.Discord.RestQueue
             logger.LogInformation("Started.");
 
             var relay = Services.GetRequiredService<IRequestMessageRelay>();
+            var invoker = Services.GetRequiredService<IRequestInvoker>();
 
             while (true)
             {
                 var messages = await relay.Receive(cancellationToken);
-                var tasks = from message in messages select relay.Complete(message, null, cancellationToken);
+                var tasks = from message in messages select invoker.Invoke(message, cancellationToken);
 
                 try
                 {

--- a/tests/RestQueue/Requests/Services/DefaultRequestInvokerTests.cs
+++ b/tests/RestQueue/Requests/Services/DefaultRequestInvokerTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using AutoFixture.AutoNSubstitute;
+using AutoFixture.NUnit3;
+
+using Brighid.Discord.Models;
+
+using FluentAssertions;
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+using NUnit.Framework;
+
+using static NSubstitute.Arg;
+
+namespace Brighid.Discord.RestQueue.Requests
+{
+    public class DefaultRequestInvokerTests
+    {
+        [TestFixture]
+        public class InvokeTests
+        {
+            [Test, Auto]
+            public async Task ShouldThrowIfCanceled(
+                RequestMessage request,
+                [Target] DefaultRequestInvoker invoker
+            )
+            {
+                var cancellationToken = new CancellationToken(true);
+                Func<Task> func = () => invoker.Invoke(request, cancellationToken);
+
+                await func.Should().ThrowAsync<OperationCanceledException>();
+            }
+
+            [Test, Auto]
+            public async Task ShouldNotThrowIfNotCanceled(
+                RequestMessage request,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                Func<Task> func = () => invoker.Invoke(request, cancellationToken);
+
+                await func.Should().NotThrowAsync<OperationCanceledException>();
+            }
+
+            [Test, Auto]
+            public async Task ShouldSendRequestWithCorrectMethod(
+                RequestMessage request,
+                [Frozen, Substitute] HttpMessageInvoker client,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                await invoker.Invoke(request, cancellationToken);
+
+                await client.Received().SendAsync(Any<HttpRequestMessage>(), Is(cancellationToken));
+                var httpRequest = GetArg<HttpRequestMessage>(client, nameof(HttpMessageInvoker.SendAsync), 0);
+
+                httpRequest.Method.Should().Be(request.RequestDetails.Endpoint.GetMethod());
+            }
+
+            [Test, Auto]
+            public async Task ShouldSendRequestWithBuiltUrl(
+                Uri url,
+                RequestMessage request,
+                [Frozen, Substitute] HttpMessageInvoker client,
+                [Frozen, Substitute] IUrlBuilder urlBuilder,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                urlBuilder.BuildFromRequest(Any<Request>()).Returns(url);
+                await invoker.Invoke(request, cancellationToken);
+
+                urlBuilder.Received().BuildFromRequest(Is(request.RequestDetails));
+                await client.Received().SendAsync(Any<HttpRequestMessage>(), Is(cancellationToken));
+                var httpRequest = GetArg<HttpRequestMessage>(client, nameof(HttpMessageInvoker.SendAsync), 0);
+
+                httpRequest.RequestUri.Should().Be(url);
+            }
+
+            [Test, Auto]
+            public async Task ShouldSendRequestWithGivenBody(
+                RequestMessage request,
+                [Frozen, Substitute] HttpMessageInvoker client,
+                [Frozen, Substitute] IUrlBuilder urlBuilder,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                await invoker.Invoke(request, cancellationToken);
+
+                await client.Received().SendAsync(Any<HttpRequestMessage>(), Is(cancellationToken));
+                var httpRequest = GetArg<HttpRequestMessage>(client, nameof(HttpMessageInvoker.SendAsync), 0);
+
+                var content = httpRequest.Content.Should().BeOfType<StringContent>().Which;
+                var contentString = await content.ReadAsStringAsync(cancellationToken);
+
+                contentString.Should().Be(request.RequestDetails.RequestBody);
+                content.Headers.ContentType!.MediaType.Should().BeEquivalentTo("application/json");
+            }
+
+            [Test, Auto]
+            public async Task ShouldSendRequestWithNoBody(
+                RequestMessage request,
+                [Frozen, Substitute] HttpMessageInvoker client,
+                [Frozen, Substitute] IUrlBuilder urlBuilder,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                request.RequestDetails = new Request(Endpoint.ChannelCreateMessage) { RequestBody = null };
+                await invoker.Invoke(request, cancellationToken);
+
+                await client.Received().SendAsync(Any<HttpRequestMessage>(), Is(cancellationToken));
+                var httpRequest = GetArg<HttpRequestMessage>(client, nameof(HttpMessageInvoker.SendAsync), 0);
+
+                httpRequest.Content.Should().BeNull();
+            }
+
+            [Test, Auto]
+            public async Task ShouldCompleteRequest(
+                string response,
+                RequestMessage request,
+                [Frozen] HttpStatusCode statusCode,
+                [Frozen] HttpResponseMessage httpResponse,
+                [Frozen, Substitute] HttpMessageInvoker client,
+                [Frozen, Substitute] IRequestMessageRelay relay,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                httpResponse.Content = new StringContent(response);
+                request.RequestDetails = new Request(Endpoint.ChannelCreateMessage) { RequestBody = null };
+                await invoker.Invoke(request, cancellationToken);
+
+                await client.Received().SendAsync(Any<HttpRequestMessage>(), Is(cancellationToken));
+                await relay.Received().Complete(Is(request), Is(statusCode), Is(response), Is(cancellationToken));
+            }
+
+            [Test, Auto]
+            public async Task ShouldFailRequestIfExceptionWasThrown(
+                string response,
+                RequestMessage request,
+                [Frozen] HttpStatusCode statusCode,
+                [Frozen] HttpResponseMessage httpResponse,
+                [Frozen, Substitute] HttpMessageInvoker client,
+                [Frozen, Substitute] IRequestMessageRelay relay,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                client.SendAsync(Any<HttpRequestMessage>(), Any<CancellationToken>()).Throws<Exception>();
+                request.RequestDetails = new Request(Endpoint.ChannelCreateMessage) { RequestBody = null };
+
+                await invoker.Invoke(request, cancellationToken);
+
+                await client.Received().SendAsync(Any<HttpRequestMessage>(), Is(cancellationToken));
+                await relay.Received().Fail(Is(request), Is(0U), Is(cancellationToken));
+            }
+
+            private static TArg GetArg<TArg>(object target, string methodName, int arg)
+            {
+                return (from call in target.ReceivedCalls()
+                        let methodInfo = call.GetMethodInfo()
+                        where methodInfo.Name == methodName
+                        select (TArg)call.GetArguments()[arg]).First();
+            }
+        }
+    }
+}

--- a/tests/RestQueue/Requests/Services/SqsRequestMessageRelayTests.cs
+++ b/tests/RestQueue/Requests/Services/SqsRequestMessageRelayTests.cs
@@ -204,7 +204,7 @@ namespace Brighid.Discord.RestQueue.Requests
                 CancellationToken cancellationToken
             )
             {
-                message.RequestDetails = new Request { ResponseQueueURL = responseQueueUrl };
+                message.RequestDetails = new Request(Endpoint.ChannelCreateMessage) { ResponseQueueURL = responseQueueUrl };
                 serializer.Serialize(Any<Response>(), Any<CancellationToken>()).Returns(payload);
                 await relay.Complete(message, statusCode, response, cancellationToken);
 
@@ -246,7 +246,7 @@ namespace Brighid.Discord.RestQueue.Requests
                 CancellationToken cancellationToken
             )
             {
-                message.RequestDetails = new Request { ResponseQueueURL = null };
+                message.RequestDetails = new Request(Endpoint.ChannelCreateMessage) { ResponseQueueURL = null };
 
                 await relay.Complete(message, statusCode, response, cancellationToken);
 

--- a/tests/RestQueue/Requests/Services/SqsRequestMessageRelayTests.cs
+++ b/tests/RestQueue/Requests/Services/SqsRequestMessageRelayTests.cs
@@ -164,7 +164,7 @@ namespace Brighid.Discord.RestQueue.Requests
                 var task2CancellationTokenSource = new CancellationTokenSource();
                 var task2 = relay.Complete(message2, statusCode, null, task2CancellationTokenSource.Token);
 
-                task2CancellationTokenSource.CancelAfter(2);
+                task2CancellationTokenSource.CancelAfter(1);
 
                 Func<Task> func = () => Task.WhenAll(task1, task2);
 
@@ -456,7 +456,7 @@ namespace Brighid.Discord.RestQueue.Requests
                 var message2CancellationSource = new CancellationTokenSource();
                 var task1 = relay.Fail(message1, message1VisibilityTimeout, message1CancellationToken);
                 var task2 = relay.Fail(message2, message2VisibilityTimeout, message2CancellationSource.Token);
-                message2CancellationSource.CancelAfter(2);
+                message2CancellationSource.CancelAfter(1);
 
                 try
                 {

--- a/tests/RestQueue/Requests/Services/SqsRequestMessageRelayTests.cs
+++ b/tests/RestQueue/Requests/Services/SqsRequestMessageRelayTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -32,11 +33,12 @@ namespace Brighid.Discord.RestQueue.Requests
             [Test, Auto]
             public async Task ShouldThrowIfCanceled(
                 RequestMessage message,
+                HttpStatusCode statusCode,
                 [Target] SqsRequestMessageRelay relay
             )
             {
                 var cancellationToken = new CancellationToken(true);
-                Func<Task> func = () => relay.Complete(message, null, cancellationToken);
+                Func<Task> func = () => relay.Complete(message, statusCode, null, cancellationToken);
 
                 await func.Should().ThrowAsync<OperationCanceledException>();
             }
@@ -44,11 +46,12 @@ namespace Brighid.Discord.RestQueue.Requests
             [Test, Auto]
             public async Task ShouldNotThrowIfNotCanceled(
                 RequestMessage message,
+                HttpStatusCode statusCode,
                 [Target] SqsRequestMessageRelay relay,
                 CancellationToken cancellationToken
             )
             {
-                Func<Task> func = () => relay.Complete(message, null, cancellationToken);
+                Func<Task> func = () => relay.Complete(message, statusCode, null, cancellationToken);
 
                 await func.Should().NotThrowAsync<OperationCanceledException>();
             }
@@ -56,13 +59,14 @@ namespace Brighid.Discord.RestQueue.Requests
             [Test, Auto, Timeout(2000)]
             public async Task ShouldDeleteMessageFromTheQueue(
                 RequestMessage message,
+                HttpStatusCode statusCode,
                 [Frozen] RequestOptions options,
                 [Frozen, Substitute] IAmazonSQS sqs,
                 [Target] SqsRequestMessageRelay relay,
                 CancellationToken cancellationToken
             )
             {
-                await relay.Complete(message, null, cancellationToken);
+                await relay.Complete(message, statusCode, null, cancellationToken);
 
                 await sqs.Received().DeleteMessageBatchAsync(
                     Is<DeleteMessageBatchRequest>(req =>
@@ -77,6 +81,7 @@ namespace Brighid.Discord.RestQueue.Requests
             [Test, Auto, Timeout(2000)]
             public async Task ShouldPropagateDeleteMessageBatchExceptions(
                 RequestMessage message,
+                HttpStatusCode statusCode,
                 Exception exception,
                 [Frozen] RequestOptions options,
                 [Frozen, Substitute] IAmazonSQS sqs,
@@ -86,7 +91,7 @@ namespace Brighid.Discord.RestQueue.Requests
             {
                 sqs.DeleteMessageBatchAsync(Any<DeleteMessageBatchRequest>(), Any<CancellationToken>()).Throws(exception);
 
-                Func<Task> func = () => relay.Complete(message, null, cancellationToken);
+                Func<Task> func = () => relay.Complete(message, statusCode, null, cancellationToken);
 
                 (await func.Should().ThrowAsync<Exception>())
                 .And.Should().Be(exception);
@@ -95,13 +100,14 @@ namespace Brighid.Discord.RestQueue.Requests
             [Test, Auto, Timeout(2000)]
             public async Task ShouldSetMessageStateToSucceeded(
                 RequestMessage message,
+                HttpStatusCode statusCode,
                 [Frozen] RequestOptions options,
                 [Frozen, Substitute] IAmazonSQS sqs,
                 [Target] SqsRequestMessageRelay relay,
                 CancellationToken cancellationToken
             )
             {
-                await relay.Complete(message, null, cancellationToken);
+                await relay.Complete(message, statusCode, null, cancellationToken);
 
                 message.State.Should().Be(RequestMessageState.Succeeded);
             }
@@ -110,14 +116,15 @@ namespace Brighid.Discord.RestQueue.Requests
             public async Task ShouldBatchMultipleCallsIntoASingleDelete(
                 RequestMessage message1,
                 RequestMessage message2,
+                HttpStatusCode statusCode,
                 [Frozen] RequestOptions options,
                 [Frozen, Substitute] IAmazonSQS sqs,
                 [Target] SqsRequestMessageRelay relay,
                 CancellationToken cancellationToken
             )
             {
-                var task1 = relay.Complete(message1, null, cancellationToken);
-                var task2 = relay.Complete(message2, null, cancellationToken);
+                var task1 = relay.Complete(message1, statusCode, null, cancellationToken);
+                var task2 = relay.Complete(message2, statusCode, null, cancellationToken);
 
                 await Task.WhenAll(task1, task2);
 
@@ -133,11 +140,11 @@ namespace Brighid.Discord.RestQueue.Requests
 
                 batchRequest.QueueUrl.Should().Be(options.QueueUrl.ToString());
                 batchRequest.Entries.Should().Contain(entry =>
-                    entry.Id == message1.Request.Id.ToString() &&
+                    entry.Id == message1.RequestDetails.Id.ToString() &&
                     entry.ReceiptHandle == message1.ReceiptHandle
                 );
                 batchRequest.Entries.Should().Contain(entry =>
-                    entry.Id == message2.Request.Id.ToString() &&
+                    entry.Id == message2.RequestDetails.Id.ToString() &&
                     entry.ReceiptHandle == message2.ReceiptHandle
                 );
             }
@@ -146,15 +153,16 @@ namespace Brighid.Discord.RestQueue.Requests
             public async Task ShouldNotDeleteMessagesThatHaveBeenCanceled(
                 RequestMessage message1,
                 RequestMessage message2,
+                HttpStatusCode statusCode,
                 [Frozen] RequestOptions options,
                 [Frozen, Substitute] IAmazonSQS sqs,
                 [Target] SqsRequestMessageRelay relay,
                 CancellationToken cancellationToken
             )
             {
-                var task1 = relay.Complete(message1, null, cancellationToken);
+                var task1 = relay.Complete(message1, statusCode, null, cancellationToken);
                 var task2CancellationTokenSource = new CancellationTokenSource();
-                var task2 = relay.Complete(message2, null, task2CancellationTokenSource.Token);
+                var task2 = relay.Complete(message2, statusCode, null, task2CancellationTokenSource.Token);
 
                 task2CancellationTokenSource.CancelAfter(2);
 
@@ -173,11 +181,11 @@ namespace Brighid.Discord.RestQueue.Requests
 
                 batchRequest.QueueUrl.Should().Be(options.QueueUrl.ToString());
                 batchRequest.Entries.Should().Contain(entry =>
-                    entry.Id == message1.Request.Id.ToString() &&
+                    entry.Id == message1.RequestDetails.Id.ToString() &&
                     entry.ReceiptHandle == message1.ReceiptHandle
                 );
                 batchRequest.Entries.Should().NotContain(entry =>
-                    entry.Id == message2.Request.Id.ToString() &&
+                    entry.Id == message2.RequestDetails.Id.ToString() &&
                     entry.ReceiptHandle == message2.ReceiptHandle
                 );
             }
@@ -188,6 +196,7 @@ namespace Brighid.Discord.RestQueue.Requests
                 string payload,
                 Uri responseQueueUrl,
                 RequestMessage message,
+                HttpStatusCode statusCode,
                 [Frozen] ISerializer serializer,
                 [Frozen] RequestOptions options,
                 [Frozen, Substitute] IAmazonSQS sqs,
@@ -195,21 +204,23 @@ namespace Brighid.Discord.RestQueue.Requests
                 CancellationToken cancellationToken
             )
             {
-                message.Request = new Request { ResponseQueueURL = responseQueueUrl };
+                message.RequestDetails = new Request { ResponseQueueURL = responseQueueUrl };
                 serializer.Serialize(Any<Response>(), Any<CancellationToken>()).Returns(payload);
-                await relay.Complete(message, response, cancellationToken);
+                await relay.Complete(message, statusCode, response, cancellationToken);
 
                 await sqs.Received().SendMessageAsync(Is(responseQueueUrl.ToString()), Is(payload), Any<CancellationToken>());
                 await serializer.Received().Serialize(Any<Response>(), Any<CancellationToken>());
 
                 var responseGivenToSerializer = (from call in serializer.ReceivedCalls() select (Response)call.GetArguments()[0]).First();
-                responseGivenToSerializer.RequestId.Should().Be(message.Request.Id);
-                responseGivenToSerializer.Message.Should().Be(message.Response);
+                responseGivenToSerializer.RequestId.Should().Be(message.RequestDetails.Id);
+                responseGivenToSerializer.StatusCode.Should().Be(statusCode);
+                responseGivenToSerializer.Body.Should().Be(message.Response);
             }
 
             [Test, Auto, Timeout(2000)]
             public async Task ShouldNotSendResponseIfResponseIsNull(
                 RequestMessage message,
+                HttpStatusCode statusCode,
                 [Frozen] ISerializer serializer,
                 [Frozen] RequestOptions options,
                 [Frozen, Substitute] IAmazonSQS sqs,
@@ -217,16 +228,17 @@ namespace Brighid.Discord.RestQueue.Requests
                 CancellationToken cancellationToken
             )
             {
-                await relay.Complete(message, null, cancellationToken);
+                await relay.Complete(message, statusCode, null, cancellationToken);
 
                 await serializer.DidNotReceive().Serialize(Any<string>(), Any<CancellationToken>());
-                await sqs.DidNotReceive().SendMessageAsync(Is(message.Request.ResponseQueueURL!.ToString()), Any<string>(), Any<CancellationToken>());
+                await sqs.DidNotReceive().SendMessageAsync(Is(message.RequestDetails.ResponseQueueURL!.ToString()), Any<string>(), Any<CancellationToken>());
             }
 
             [Test, Auto, Timeout(2000)]
             public async Task ShouldNotSendResponseIfResponseQueueUrlIsNull(
                 string response,
                 RequestMessage message,
+                HttpStatusCode statusCode,
                 [Frozen] ISerializer serializer,
                 [Frozen] RequestOptions options,
                 [Frozen, Substitute] IAmazonSQS sqs,
@@ -234,9 +246,9 @@ namespace Brighid.Discord.RestQueue.Requests
                 CancellationToken cancellationToken
             )
             {
-                message.Request = new Request { ResponseQueueURL = null };
+                message.RequestDetails = new Request { ResponseQueueURL = null };
 
-                await relay.Complete(message, response, cancellationToken);
+                await relay.Complete(message, statusCode, response, cancellationToken);
 
                 await serializer.DidNotReceive().Serialize(Is(response), Any<CancellationToken>());
                 await sqs.DidNotReceive().SendMessageAsync(Any<string>(), Any<string>(), Any<CancellationToken>());
@@ -245,6 +257,7 @@ namespace Brighid.Discord.RestQueue.Requests
             [Test, Auto, Timeout(2000)]
             public async Task ShouldPropagateSendMessageExceptions(
                 string response,
+                HttpStatusCode statusCode,
                 RequestMessage message,
                 Exception exception,
                 [Frozen] RequestOptions options,
@@ -254,7 +267,7 @@ namespace Brighid.Discord.RestQueue.Requests
             )
             {
                 sqs.SendMessageAsync(Any<string>(), Any<string>(), Any<CancellationToken>()).Throws(exception);
-                Func<Task> func = () => relay.Complete(message, response, cancellationToken);
+                Func<Task> func = () => relay.Complete(message, statusCode, response, cancellationToken);
 
                 (await func.Should().ThrowAsync<Exception>())
                 .And.Message.Should().Be(exception.Message);
@@ -263,6 +276,7 @@ namespace Brighid.Discord.RestQueue.Requests
             [Test, Auto, Timeout(2000)]
             public async Task ShouldPropagateSerializeExceptions(
                 string response,
+                HttpStatusCode statusCode,
                 RequestMessage message,
                 Exception exception,
                 [Frozen] ISerializer serializer,
@@ -273,7 +287,7 @@ namespace Brighid.Discord.RestQueue.Requests
             )
             {
                 serializer.Serialize(Any<Response>(), Any<CancellationToken>()).Throws(exception);
-                Func<Task> func = () => relay.Complete(message, response, cancellationToken);
+                Func<Task> func = () => relay.Complete(message, statusCode, response, cancellationToken);
 
                 (await func.Should().ThrowAsync<Exception>())
                 .And.Message.Should().Be(exception.Message);
@@ -282,6 +296,7 @@ namespace Brighid.Discord.RestQueue.Requests
             [Test, Auto, Timeout(2000)]
             public async Task ShouldThrowIfMessageFailedToDelete(
                 string response,
+                HttpStatusCode statusCode,
                 RequestMessage message,
                 Exception exception,
                 [Frozen] ISerializer serializer,
@@ -295,11 +310,11 @@ namespace Brighid.Discord.RestQueue.Requests
                 {
                     Failed = new List<BatchResultErrorEntry>
                     {
-                        new() { Id = message.Request.Id.ToString() },
+                        new() { Id = message.RequestDetails.Id.ToString() },
                     },
                 });
 
-                Func<Task> func = () => relay.Complete(message, response, cancellationToken);
+                Func<Task> func = () => relay.Complete(message, statusCode, response, cancellationToken);
 
                 (await func.Should().ThrowAsync<RequestMessageNotDeletedException>())
                 .And.RequestMessage.Should().Be(message);
@@ -382,7 +397,7 @@ namespace Brighid.Discord.RestQueue.Requests
                                                select entries).First();
 
                 changeVisibilityEntries.Should().Contain(entry =>
-                    entry.Id == message.Request.Id.ToString() &&
+                    entry.Id == message.RequestDetails.Id.ToString() &&
                     entry.ReceiptHandle == message.ReceiptHandle &&
                     entry.VisibilityTimeout == visibilityTimeout
                 );
@@ -414,13 +429,13 @@ namespace Brighid.Discord.RestQueue.Requests
                                                select entries).First();
 
                 changeVisibilityEntries.Should().Contain(entry =>
-                    entry.Id == message1.Request.Id.ToString() &&
+                    entry.Id == message1.RequestDetails.Id.ToString() &&
                     entry.ReceiptHandle == message1.ReceiptHandle &&
                     entry.VisibilityTimeout == message1VisibilityTimeout
                 );
 
                 changeVisibilityEntries.Should().Contain(entry =>
-                    entry.Id == message2.Request.Id.ToString() &&
+                    entry.Id == message2.RequestDetails.Id.ToString() &&
                     entry.ReceiptHandle == message2.ReceiptHandle &&
                     entry.VisibilityTimeout == message2VisibilityTimeout
                 );
@@ -460,13 +475,13 @@ namespace Brighid.Discord.RestQueue.Requests
                                                select entries).First();
 
                 changeVisibilityEntries.Should().Contain(entry =>
-                    entry.Id == message1.Request.Id.ToString() &&
+                    entry.Id == message1.RequestDetails.Id.ToString() &&
                     entry.ReceiptHandle == message1.ReceiptHandle &&
                     entry.VisibilityTimeout == message1VisibilityTimeout
                 );
 
                 changeVisibilityEntries.Should().NotContain(entry =>
-                    entry.Id == message2.Request.Id.ToString() &&
+                    entry.Id == message2.RequestDetails.Id.ToString() &&
                     entry.ReceiptHandle == message2.ReceiptHandle &&
                     entry.VisibilityTimeout == message2VisibilityTimeout
                 );
@@ -508,7 +523,7 @@ namespace Brighid.Discord.RestQueue.Requests
                 {
                     Failed = new List<BatchResultErrorEntry>
                     {
-                        new() { Id = message.Request.Id.ToString() },
+                        new() { Id = message.RequestDetails.Id.ToString() },
                     },
                 });
 
@@ -580,7 +595,7 @@ namespace Brighid.Discord.RestQueue.Requests
                 var result = await relay.Receive(cancellationToken);
                 var resultMessage = result.ElementAt(0);
 
-                resultMessage.Request.Should().Be(request);
+                resultMessage.RequestDetails.Should().Be(request);
                 resultMessage.State.Should().Be(RequestMessageState.InFlight);
                 resultMessage.ReceiptHandle.Should().Be(sqsMessage.ReceiptHandle);
                 await serializer.Received().Deserialize<Request>(Is(sqsMessage.Body), Is(cancellationToken));


### PR DESCRIPTION
Creates a service that is used to invoke requests to the Discord API, then use the message relay to mark that message as complete or failed depending on what happened.