### PR TITLE
BRGD-74 Gateway TX Worker Refactor - Use Timer

### DIFF
--- a/src/Adapter/Gateway/Services/DefaultGatewayService.cs
+++ b/src/Adapter/Gateway/Services/DefaultGatewayService.cs
@@ -83,7 +83,7 @@ namespace Brighid.Discord.Adapter.Gateway
 
             var cancellationTokenSource = new CancellationTokenSource();
             await rxWorker.Start(this);
-            txWorker.Start(this, webSocket, cancellationTokenSource);
+            await txWorker.Start(this, webSocket);
 
             worker = timerFactory.CreateTimer(Run, 0, WorkerThreadName);
             worker.StopOnException = true;
@@ -97,9 +97,8 @@ namespace Brighid.Discord.Adapter.Gateway
             IsRunning = false;
             await StopHeartbeat();
             await worker!.Stop();
-
             await rxWorker.Stop();
-            txWorker.Stop();
+            await txWorker.Stop();
             webSocket?.Abort();
             webSocket = null;
             worker = null;

--- a/src/Adapter/Gateway/Services/DefaultGatewayTxWorker.cs
+++ b/src/Adapter/Gateway/Services/DefaultGatewayTxWorker.cs
@@ -17,78 +17,96 @@ namespace Brighid.Discord.Adapter.Gateway
         private const string WorkerThreadName = "Gateway TX";
         private readonly IChannel<GatewayMessage> channel;
         private readonly ISerializer serializer;
+        private readonly ITimerFactory timerFactory;
         private readonly IGatewayUtilsFactory gatewayUtilsFactory;
         private readonly ILogger<DefaultGatewayTxWorker> logger;
-        private CancellationToken cancellationToken;
-        private IWorkerThread? workerThread;
+        private ITimer? timer;
         private IClientWebSocket? webSocket;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultGatewayTxWorker" /> class.
         /// </summary>
         /// <param name="serializer">Serializer used for deserializing messages from the gateway.</param>
+        /// <param name="timerFactory">Factory used to create timers.</param>
         /// <param name="gatewayUtilsFactory">Factory to create various utils with.</param>
         /// <param name="logger">Logger used to log information to some destination(s).</param>
         public DefaultGatewayTxWorker(
             ISerializer serializer,
+            ITimerFactory timerFactory,
             IGatewayUtilsFactory gatewayUtilsFactory,
             ILogger<DefaultGatewayTxWorker> logger
         )
         {
             this.serializer = serializer;
+            this.timerFactory = timerFactory;
             this.logger = logger;
             this.gatewayUtilsFactory = gatewayUtilsFactory;
             channel = gatewayUtilsFactory.CreateChannel<GatewayMessage>();
         }
 
         /// <inheritdoc />
-        public void Start(IGatewayService gateway, IClientWebSocket webSocket, CancellationTokenSource cancellationTokenSource)
+        public bool IsRunning { get; private set; }
+
+        /// <inheritdoc />
+        public async Task Start(IGatewayService gateway, IClientWebSocket webSocket)
         {
-            cancellationToken = cancellationTokenSource.Token;
+            IsRunning = true;
             this.webSocket = webSocket;
-            workerThread = gatewayUtilsFactory.CreateWorkerThread(Run, WorkerThreadName);
-            workerThread.OnUnexpectedStop = () => gateway.Restart();
-            workerThread.Start(cancellationTokenSource);
+
+            timer = timerFactory.CreateTimer(Run, 0, WorkerThreadName);
+            timer.StopOnException = true;
+            timer.OnUnexpectedStop = () => gateway.Restart();
+            await timer.Start();
         }
 
         /// <inheritdoc />
-        public void Stop()
+        public async Task Stop()
         {
-            workerThread?.Stop();
-            workerThread = null;
+            IsRunning = false;
+            await timer!.Stop();
+            timer = null;
         }
 
         /// <inheritdoc />
         public async Task Emit(GatewayMessage message, CancellationToken cancellationToken)
         {
-            this.cancellationToken.ThrowIfCancellationRequested();
             cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfNotRunning();
             await channel.Write(message, cancellationToken);
         }
 
         /// <summary>
         /// Runs the Gateway TX Worker.
         /// </summary>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The resulting task.</returns>
-        public async Task Run()
+        public async Task Run(CancellationToken cancellationToken = default)
         {
-            while (!cancellationToken.IsCancellationRequested)
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfNotRunning();
+
+            while (webSocket?.State != WebSocketState.Open)
             {
-                while (webSocket?.State != WebSocketState.Open)
-                {
-                    await gatewayUtilsFactory.CreateDelay(100, cancellationToken);
-                }
+                await gatewayUtilsFactory.CreateDelay(100, cancellationToken);
+            }
 
-                if (!await channel.WaitToRead(cancellationToken))
-                {
-                    continue;
-                }
+            if (!await channel.WaitToRead(cancellationToken))
+            {
+                return;
+            }
 
-                var message = await channel.Read(cancellationToken);
-                var serializedMessage = await serializer.SerializeToBytes(message, cancellationToken);
+            var message = await channel.Read(cancellationToken);
+            var serializedMessage = await serializer.SerializeToBytes(message, cancellationToken);
 
-                logger.LogInformation("Sending Message: {@message}", message);
-                await webSocket!.Send(serializedMessage, WebSocketMessageType.Text, true, cancellationToken);
+            logger.LogInformation("Sending Message: {@message}", message);
+            await webSocket!.Send(serializedMessage, WebSocketMessageType.Text, true, cancellationToken);
+        }
+
+        private void ThrowIfNotRunning()
+        {
+            if (!IsRunning)
+            {
+                throw new System.OperationCanceledException();
             }
         }
     }

--- a/src/Adapter/Gateway/Services/IGatewayTxWorker.cs
+++ b/src/Adapter/Gateway/Services/IGatewayTxWorker.cs
@@ -11,17 +11,23 @@ namespace Brighid.Discord.Adapter.Gateway
     public interface IGatewayTxWorker
     {
         /// <summary>
+        /// Gets a value indicating whether the service is running.
+        /// </summary>
+        bool IsRunning { get; }
+
+        /// <summary>
         /// Start the worker.
         /// </summary>
         /// <param name="gateway">The gateway service to use.</param>
         /// <param name="webSocket">The webSocket to send messages to.</param>
-        /// <param name="cancellationTokenSource">Source token used to cancel the worker's thread.</param>
-        void Start(IGatewayService gateway, IClientWebSocket webSocket, CancellationTokenSource cancellationTokenSource);
+        /// <returns>The resulting task.</returns>
+        Task Start(IGatewayService gateway, IClientWebSocket webSocket);
 
         /// <summary>
         /// Stop the gateway worker.
         /// </summary>
-        void Stop();
+        /// <returns>The resulting task.</returns>
+        Task Stop();
 
         /// <summary>
         /// Emit bytes to the worker for processing.

--- a/tests/Adapter/Gateway/Services/DefaultGatewayServiceTests.cs
+++ b/tests/Adapter/Gateway/Services/DefaultGatewayServiceTests.cs
@@ -71,7 +71,7 @@ namespace Brighid.Discord.Adapter.Gateway
             {
                 await gateway.StartAsync();
 
-                txWorker.Received().Start(Is(gateway), Is(clientWebSocket), Any<CancellationTokenSource>());
+                await txWorker.Received().Start(Is(gateway), Is(clientWebSocket));
             }
 
             [Test, Auto]
@@ -154,7 +154,7 @@ namespace Brighid.Discord.Adapter.Gateway
                 await gateway.StartAsync();
                 await gateway.StopAsync();
 
-                txWorker.Received().Stop();
+                await txWorker.Received().Stop();
             }
 
             [Test, Auto, Timeout(1000)]


### PR DESCRIPTION
This refactors the tx worker to use an ITimer instead of IWorkerThread for more clarity and easier testing (don't have to setup loop breakouts)