### PR TITLE
BRGD-77 Bucket Service Update Methods

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./:/app
       - ~/.aws:/root/.aws
     environment:
-      
+      Environment: local
       CONFIGURATION: Debug
       Database__Host: db
       Database__Name: ${DB_NAME}

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -9,7 +9,7 @@
             ]
         },
         "dotnet-ef": {
-            "version": "5.0.0",
+            "version": "5.0.6",
             "commands": [
                 "dotnet-ef"
             ]

--- a/src/Adapter/AdapterHost.cs
+++ b/src/Adapter/AdapterHost.cs
@@ -4,6 +4,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Brighid.Discord.Adapter.Database;
+
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -43,6 +46,9 @@ namespace Brighid.Discord.Adapter
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {
             logger.LogInformation("Starting.");
+
+            using var databaseContext = Services.GetRequiredService<DatabaseContext>();
+            await databaseContext.Database.EnsureCreatedAsync(cancellationToken);
 
             var tasks = from service in hostedServices select service.StartAsync(cancellationToken);
             await Task.WhenAll(tasks);

--- a/src/Adapter/AdapterHost.cs
+++ b/src/Adapter/AdapterHost.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Brighid.Discord.Adapter.Database;
 
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -20,6 +21,7 @@ namespace Brighid.Discord.Adapter
     {
         private const string LogCategoryName = "Adapter Host";
         private readonly IEnumerable<IHostedService> hostedServices;
+        private readonly IHostEnvironment environment;
         private readonly ILogger<AdapterHost> logger;
 
         /// <summary>
@@ -27,15 +29,18 @@ namespace Brighid.Discord.Adapter
         /// </summary>
         /// <param name="hostedServices">List of hosted services to start.</param>
         /// <param name="logger">Logger used to log info to some destination(s).</param>
+        /// <param name="environment">Service used to get info about the environment.</param>
         /// <param name="services">The service provider to use for accessing host services.</param>
         public AdapterHost(
             IEnumerable<IHostedService> hostedServices,
             ILogger<AdapterHost> logger,
+            IHostEnvironment environment,
             IServiceProvider services
         )
         {
             Services = services;
             this.hostedServices = hostedServices;
+            this.environment = environment;
             this.logger = logger;
         }
 
@@ -45,10 +50,13 @@ namespace Brighid.Discord.Adapter
         /// <inheritdoc />
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {
-            logger.LogInformation("Starting.");
+            logger.LogInformation("Starting. Environment: {@environment}", environment.EnvironmentName);
 
-            using var databaseContext = Services.GetRequiredService<DatabaseContext>();
-            await databaseContext.Database.EnsureCreatedAsync(cancellationToken);
+            if (environment.IsEnvironment("local"))
+            {
+                using var databaseContext = Services.GetRequiredService<DatabaseContext>();
+                await databaseContext.Database.MigrateAsync(cancellationToken);
+            }
 
             var tasks = from service in hostedServices select service.StartAsync(cancellationToken);
             await Task.WhenAll(tasks);

--- a/src/Adapter/Database/Migrations/20210518134319_BucketPrimaryKeyChanges.Designer.cs
+++ b/src/Adapter/Database/Migrations/20210518134319_BucketPrimaryKeyChanges.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Brighid.Discord.Adapter.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Brighid.Discord.Adapter.Database
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20210518134319_BucketPrimaryKeyChanges")]
+    partial class BucketPrimaryKeyChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Adapter/Database/Migrations/20210518134319_BucketPrimaryKeyChanges.cs
+++ b/src/Adapter/Database/Migrations/20210518134319_BucketPrimaryKeyChanges.cs
@@ -4,6 +4,11 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Brighid.Discord.Adapter.Database
 {
+    /// <summary>
+    /// Since we could have multiple rows with the same RemoteId but different
+    /// major parameters, the RemoteId cannot be the primary key.  Instead we are defining
+    /// a separate primary key with a Guid that has no relevance to the bucket ID returned by Discord.
+    /// </summary>
     public partial class BucketPrimaryKeyChanges : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/src/Adapter/Database/Migrations/20210518134319_BucketPrimaryKeyChanges.cs
+++ b/src/Adapter/Database/Migrations/20210518134319_BucketPrimaryKeyChanges.cs
@@ -1,0 +1,96 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Brighid.Discord.Adapter.Database
+{
+    public partial class BucketPrimaryKeyChanges : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Buckets",
+                table: "Buckets");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MajorParameters",
+                table: "Buckets",
+                type: "longtext",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext CHARACTER SET utf8mb4")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RemoteId",
+                table: "Buckets",
+                type: "varchar(255)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(255)")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "Id",
+                table: "Buckets",
+                type: "binary(16)",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Buckets",
+                table: "Buckets",
+                column: "Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Buckets_RemoteId",
+                table: "Buckets",
+                column: "RemoteId",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Buckets",
+                table: "Buckets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Buckets_RemoteId",
+                table: "Buckets");
+
+            migrationBuilder.DropColumn(
+                name: "Id",
+                table: "Buckets");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RemoteId",
+                table: "Buckets",
+                type: "varchar(255)",
+                nullable: false,
+                defaultValue: string.Empty,
+                oldClrType: typeof(string),
+                oldType: "varchar(255)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MajorParameters",
+                table: "Buckets",
+                type: "longtext CHARACTER SET utf8mb4",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Buckets",
+                table: "Buckets",
+                column: "RemoteId");
+        }
+    }
+}

--- a/src/Adapter/Database/Migrations/20210518143038_BucketsRemoveUniqueIndex.Designer.cs
+++ b/src/Adapter/Database/Migrations/20210518143038_BucketsRemoveUniqueIndex.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Brighid.Discord.Adapter.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Brighid.Discord.Adapter.Database
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20210518143038_BucketsRemoveUniqueIndex")]
+    partial class BucketsRemoveUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Adapter/Database/Migrations/20210518143038_BucketsRemoveUniqueIndex.cs
+++ b/src/Adapter/Database/Migrations/20210518143038_BucketsRemoveUniqueIndex.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Brighid.Discord.Adapter.Database
+{
+    public partial class BucketsRemoveUniqueIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Buckets_RemoteId",
+                table: "Buckets");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Buckets_RemoteId",
+                table: "Buckets",
+                column: "RemoteId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Buckets_RemoteId",
+                table: "Buckets");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Buckets_RemoteId",
+                table: "Buckets",
+                column: "RemoteId",
+                unique: true);
+        }
+    }
+}

--- a/src/Adapter/Database/Migrations/20210518143038_BucketsRemoveUniqueIndex.cs
+++ b/src/Adapter/Database/Migrations/20210518143038_BucketsRemoveUniqueIndex.cs
@@ -2,6 +2,9 @@
 
 namespace Brighid.Discord.Adapter.Database
 {
+    /// <summary>
+    /// This removes the unique index on the RemoteId column of the Buckets table.
+    /// </summary>
     public partial class BucketsRemoveUniqueIndex : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/src/Adapter/Program.cs
+++ b/src/Adapter/Program.cs
@@ -26,6 +26,10 @@ namespace Brighid.Discord.Adapter
         {
             return Host.CreateDefaultBuilder(args)
                 .UseSerilog(dispose: true)
+                .ConfigureHostConfiguration(config =>
+                {
+                    config.AddEnvironmentVariables();
+                })
                 .ConfigureServices((context, services) =>
                 {
                     CreateStartup(context.Configuration).ConfigureServices(services);

--- a/src/Adapter/Requests/Models/Bucket.cs
+++ b/src/Adapter/Requests/Models/Bucket.cs
@@ -15,6 +15,12 @@ namespace Brighid.Discord.Adapter.Requests
     public class Bucket
     {
         /// <summary>
+        /// Gets or sets the primary key of the rate limit bucket.
+        /// </summary>
+        [Key]
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        /// <summary>
         /// Gets or sets the API category associated with the endpoints in this bucket.
         /// </summary>
         public char ApiCategory { get; set; }
@@ -27,8 +33,7 @@ namespace Brighid.Discord.Adapter.Requests
         /// <summary>
         /// Gets or sets the ID of this bucket that was returned from the Discord API.
         /// </summary>
-        [Key]
-        public string RemoteId { get; set; } = Guid.NewGuid().ToString();
+        public string? RemoteId { get; set; }
 
         /// <summary>
         /// Gets or sets the major parameters associated with this bucket, separated by '/'.
@@ -95,6 +100,10 @@ namespace Brighid.Discord.Adapter.Requests
             /// <inheritdoc />
             public void Configure(EntityTypeBuilder<Bucket> builder)
             {
+                builder
+                .HasIndex(bucket => bucket.RemoteId)
+                .IsUnique();
+
                 builder
                 .Property(bucket => bucket.MajorParameters)
                 .HasConversion(new ValueConverter<MajorParameters, string>(

--- a/src/Adapter/Requests/Models/Bucket.cs
+++ b/src/Adapter/Requests/Models/Bucket.cs
@@ -100,9 +100,7 @@ namespace Brighid.Discord.Adapter.Requests
             /// <inheritdoc />
             public void Configure(EntityTypeBuilder<Bucket> builder)
             {
-                builder
-                .HasIndex(bucket => bucket.RemoteId)
-                .IsUnique();
+                builder.HasIndex(bucket => bucket.RemoteId);
 
                 builder
                 .Property(bucket => bucket.MajorParameters)

--- a/src/Adapter/Requests/Services/DefaultBucketRepository.cs
+++ b/src/Adapter/Requests/Services/DefaultBucketRepository.cs
@@ -31,13 +31,16 @@ namespace Brighid.Discord.Adapter.Requests
         {
             cancellationToken.ThrowIfCancellationRequested();
             var entry = await databaseContext.AddAsync(bucket, cancellationToken);
+            await databaseContext.SaveChangesAsync(cancellationToken);
             return entry.Entity;
         }
 
         /// <inheritdoc />
-        public void Remove(Bucket bucket)
+        public async Task Remove(Bucket bucket, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             databaseContext.Remove(bucket);
+            await databaseContext.SaveChangesAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -48,12 +51,13 @@ namespace Brighid.Discord.Adapter.Requests
         }
 
         /// <inheritdoc />
-        public async Task<Bucket?> FindByRemoteId(string remoteId, CancellationToken cancellationToken = default)
+        public async Task<Bucket?> FindByRemoteIdAndMajorParameters(string remoteId, MajorParameters parameters, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var query = databaseContext.Buckets.FromSqlInterpolated(
                 $@"select * from Buckets 
                     where RemoteId={remoteId}
+                    and MajorParameters={parameters.Value}
                     for update
                 "
             );

--- a/src/Adapter/Requests/Services/DefaultBucketService.cs
+++ b/src/Adapter/Requests/Services/DefaultBucketService.cs
@@ -76,14 +76,14 @@ namespace Brighid.Discord.Adapter.Requests
                 return bucket;
             }
 
-            var existingBucket = await repository.FindByRemoteId(remoteId, cancellationToken);
+            var existingBucket = await repository.FindByRemoteIdAndMajorParameters(remoteId, bucket.MajorParameters, cancellationToken);
             if (existingBucket == null)
             {
                 bucket.RemoteId = remoteId;
                 return bucket;
             }
 
-            repository.Remove(bucket);
+            await repository.Remove(bucket, cancellationToken);
             existingBucket.Endpoints |= bucket.Endpoints;
             return existingBucket;
         }

--- a/src/Adapter/Requests/Services/DefaultBucketService.cs
+++ b/src/Adapter/Requests/Services/DefaultBucketService.cs
@@ -1,34 +1,44 @@
 using System;
+using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Brighid.Discord.Models;
 using Brighid.Discord.Threading;
 
+using Microsoft.Extensions.Logging;
+
 namespace Brighid.Discord.Adapter.Requests
 {
     /// <inheritdoc />
     public class DefaultBucketService : IBucketService
     {
+        private const string RateLimitResetHeader = "x-ratelimit-reset";
+        private const string RateLimitRemainingHeader = "x-ratelimit-remaining";
+        private const string RateLimitBucketHeader = "x-ratelimit-bucket";
         private readonly IBucketRepository repository;
         private readonly ITimerFactory timerFactory;
+        private readonly ILogger<DefaultBucketService> logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBucketService" /> class.
         /// </summary>
         /// <param name="repository">Repository to search for buckets in.</param>
         /// <param name="timerFactory">Factory to create timers and delays with.</param>
+        /// <param name="logger">Logger used to log info to some destination(s).</param>
         public DefaultBucketService(
             IBucketRepository repository,
-            ITimerFactory timerFactory
+            ITimerFactory timerFactory,
+            ILogger<DefaultBucketService> logger
         )
         {
             this.repository = repository;
             this.timerFactory = timerFactory;
+            this.logger = logger;
         }
 
         /// <inheritdoc />
-        /// <todo>Transaction handling / row read locking.</todo>
         public async Task<Bucket> GetBucketAndWaitForAvailability(Request request, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -46,8 +56,72 @@ namespace Brighid.Discord.Adapter.Requests
             }
 
             bucket.HitsRemaining--;
-            await repository.Save(bucket, cancellationToken);
             return bucket;
+        }
+
+        /// <inheritdoc />
+        public async Task<Bucket> MergeBucketIds(Bucket bucket, HttpResponseMessage response, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!response.Headers.TryGetValues(RateLimitBucketHeader, out var headerValues))
+            {
+                logger.LogWarning($"Response did not have {RateLimitBucketHeader} header.");
+                return bucket;
+            }
+
+            var remoteId = headerValues.First();
+            if (bucket.RemoteId != null)
+            {
+                bucket.RemoteId = remoteId;
+                return bucket;
+            }
+
+            var existingBucket = await repository.FindByRemoteId(remoteId, cancellationToken);
+            if (existingBucket == null)
+            {
+                bucket.RemoteId = remoteId;
+                return bucket;
+            }
+
+            repository.Remove(bucket);
+            existingBucket.Endpoints |= bucket.Endpoints;
+            return existingBucket;
+        }
+
+        /// <inheritdoc />
+        public void UpdateBucketResetAfter(Bucket bucket, HttpResponseMessage response)
+        {
+            if (!response.Headers.TryGetValues(RateLimitResetHeader, out var values))
+            {
+                logger.LogWarning($"Response did not have {RateLimitResetHeader} header.");
+                return;
+            }
+
+            if (!long.TryParse(values.First(), out var resetAfterSeconds))
+            {
+                logger.LogWarning($"Response had a non-numeric {RateLimitResetHeader} header value.");
+                return;
+            }
+
+            bucket.ResetAfter = DateTimeOffset.FromUnixTimeSeconds(resetAfterSeconds);
+        }
+
+        /// <inheritdoc />
+        public void UpdateBucketHitsRemaining(Bucket bucket, HttpResponseMessage response)
+        {
+            if (!response.Headers.TryGetValues(RateLimitRemainingHeader, out var headerValues))
+            {
+                logger.LogWarning($"Response did not have {RateLimitRemainingHeader} header.");
+                return;
+            }
+
+            if (!int.TryParse(headerValues.First(), out var hitsRemaining))
+            {
+                logger.LogWarning($"Response had a non-numeric {hitsRemaining} header value.");
+                return;
+            }
+
+            bucket.HitsRemaining = hitsRemaining;
         }
 
         private async Task<Bucket> CreateBucket(Request request, CancellationToken cancellationToken = default)
@@ -56,7 +130,7 @@ namespace Brighid.Discord.Adapter.Requests
             {
                 MajorParameters = request.Parameters,
                 HitsRemaining = 1,
-                ResetAfter = DateTimeOffset.Now + TimeSpan.FromMinutes(1),
+                ResetAfter = DateTimeOffset.Now + TimeSpan.FromMinutes(0.1),
             };
 
             bucket.AddEndpoint(request.Endpoint);

--- a/src/Adapter/Requests/Services/DefaultBucketService.cs
+++ b/src/Adapter/Requests/Services/DefaultBucketService.cs
@@ -130,7 +130,7 @@ namespace Brighid.Discord.Adapter.Requests
             {
                 MajorParameters = request.Parameters,
                 HitsRemaining = 1,
-                ResetAfter = DateTimeOffset.Now + TimeSpan.FromMinutes(0.1),
+                ResetAfter = DateTimeOffset.Now,
             };
 
             bucket.AddEndpoint(request.Endpoint);

--- a/src/Adapter/Requests/Services/DefaultRequestInvoker.cs
+++ b/src/Adapter/Requests/Services/DefaultRequestInvoker.cs
@@ -91,7 +91,10 @@ namespace Brighid.Discord.Adapter.Requests
                 _ = reporter.Report(default(RestApiFailedMessageMetric), cancellationToken);
             }
 
-            await SaveBucket(bucket, cancellationToken);
+            if (bucket != null)
+            {
+                await bucketRepository.Save(bucket, cancellationToken);
+            }
         }
 
         private static HttpContent? CreateContent(RequestMessage request)
@@ -104,20 +107,6 @@ namespace Brighid.Discord.Adapter.Requests
             var content = new StringContent(request.RequestDetails.RequestBody);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
             return content;
-        }
-
-        private async Task SaveBucket(Bucket? bucket, CancellationToken cancellationToken)
-        {
-            try
-            {
-                if (bucket != null)
-                {
-                    await bucketRepository.Save(bucket, cancellationToken);
-                }
-            }
-            catch (Exception)
-            {
-            }
         }
     }
 }

--- a/src/Adapter/Requests/Services/IBucketRepository.cs
+++ b/src/Adapter/Requests/Services/IBucketRepository.cs
@@ -19,6 +19,12 @@ namespace Brighid.Discord.Adapter.Requests
         Task<Bucket> Add(Bucket bucket, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Deletes an existing bucket.
+        /// </summary>
+        /// <param name="bucket">Bucket to delete.</param>
+        void Remove(Bucket bucket);
+
+        /// <summary>
         /// Save a bucket in the repository.
         /// </summary>
         /// <param name="bucket">Bucket to save.</param>

--- a/src/Adapter/Requests/Services/IBucketRepository.cs
+++ b/src/Adapter/Requests/Services/IBucketRepository.cs
@@ -22,7 +22,9 @@ namespace Brighid.Discord.Adapter.Requests
         /// Deletes an existing bucket.
         /// </summary>
         /// <param name="bucket">Bucket to delete.</param>
-        void Remove(Bucket bucket);
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The resulting task.</returns>
+        Task Remove(Bucket bucket, CancellationToken cancellationToken);
 
         /// <summary>
         /// Save a bucket in the repository.
@@ -36,9 +38,10 @@ namespace Brighid.Discord.Adapter.Requests
         /// Find a bucket by it's remote ID.
         /// </summary>
         /// <param name="remoteId">The remote ID to look for.</param>
+        /// <param name="parameters">The major parameters to look for.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The resulting bucket, or null if not found.</returns>
-        Task<Bucket?> FindByRemoteId(string remoteId, CancellationToken cancellationToken = default);
+        Task<Bucket?> FindByRemoteIdAndMajorParameters(string remoteId, MajorParameters parameters, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Find a bucket by it's endpoint and major parameters.

--- a/src/Adapter/Requests/Services/IBucketService.cs
+++ b/src/Adapter/Requests/Services/IBucketService.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,5 +18,28 @@ namespace Brighid.Discord.Adapter.Requests
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that will complete when the bucket becomes available again.</returns>
         Task<Bucket> GetBucketAndWaitForAvailability(Request request, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Given an HTTP Response, add a bucket's remote ID, or merge this bucket with an old one.
+        /// </summary>
+        /// <param name="bucket">Bucket to update.</param>
+        /// <param name="response">The HTTP Response to pull the bucket ID from.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The resulting bucket.</returns>
+        Task<Bucket> MergeBucketIds(Bucket bucket, HttpResponseMessage response, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Given an HTTP Response, update a bucket's rate limit reset after value.
+        /// </summary>
+        /// <param name="bucket">The bucket to update.</param>
+        /// <param name="response">The HTTP Response to pull the reset after value from.</param>
+        void UpdateBucketResetAfter(Bucket bucket, HttpResponseMessage response);
+
+        /// <summary>
+        /// Given an HTTP Response, update a bucket's hits remaining value.
+        /// </summary>
+        /// <param name="bucket">The bucket to update.</param>
+        /// <param name="response">The HTTP Response to pull the hits remaining value from.</param>
+        void UpdateBucketHitsRemaining(Bucket bucket, HttpResponseMessage response);
     }
 }

--- a/tests/Adapter/Requests/Services/DefaultBucketServiceTests.cs
+++ b/tests/Adapter/Requests/Services/DefaultBucketServiceTests.cs
@@ -83,7 +83,7 @@ namespace Brighid.Discord.Adapter.Requests
                 CancellationToken cancellationToken
             )
             {
-                var resetAfter = DateTimeOffset.Now + TimeSpan.FromMinutes(0.1);
+                var resetAfter = DateTimeOffset.Now;
                 repository.FindByEndpointAndMajorParameters(Any<Endpoint>(), Any<MajorParameters>(), Any<CancellationToken>()).Returns((Bucket?)null);
                 await service.GetBucketAndWaitForAvailability(request, cancellationToken);
 

--- a/tests/Adapter/Requests/Services/DefaultBucketServiceTests.cs
+++ b/tests/Adapter/Requests/Services/DefaultBucketServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -82,7 +83,7 @@ namespace Brighid.Discord.Adapter.Requests
                 CancellationToken cancellationToken
             )
             {
-                var resetAfter = DateTimeOffset.Now + TimeSpan.FromMinutes(1);
+                var resetAfter = DateTimeOffset.Now + TimeSpan.FromMinutes(0.1);
                 repository.FindByEndpointAndMajorParameters(Any<Endpoint>(), Any<MajorParameters>(), Any<CancellationToken>()).Returns((Bucket?)null);
                 await service.GetBucketAndWaitForAvailability(request, cancellationToken);
 
@@ -168,7 +169,6 @@ namespace Brighid.Discord.Adapter.Requests
                 var result = await service.GetBucketAndWaitForAvailability(request, cancellationToken);
 
                 result.HitsRemaining.Should().Be(1);
-                await repository.Received().Save(Is<Bucket>(recv => recv == bucket && recv.HitsRemaining == 1), Is(cancellationToken));
             }
 
             [Test, Auto]
@@ -185,7 +185,6 @@ namespace Brighid.Discord.Adapter.Requests
                 var result = await service.GetBucketAndWaitForAvailability(request, cancellationToken);
 
                 result.HitsRemaining.Should().Be(0);
-                await repository.Received().Save(Is<Bucket>(recv => recv == bucket && recv.HitsRemaining == 0), Is(cancellationToken));
             }
 
             [Test, Auto]
@@ -201,6 +200,240 @@ namespace Brighid.Discord.Adapter.Requests
                 var result = await service.GetBucketAndWaitForAvailability(request, cancellationToken);
 
                 result.Should().Be(bucket);
+            }
+        }
+
+        [TestFixture]
+        public class MergeBucketIdsTests
+        {
+            [Test, Auto]
+            public async Task ShouldThrowIfCancelled(
+                Bucket bucket,
+                [Target] DefaultBucketService service
+            )
+            {
+                var httpResponse = new HttpResponseMessage();
+                var cancellationToken = new CancellationToken(true);
+
+                Func<Task> func = () => service.MergeBucketIds(bucket, httpResponse, cancellationToken);
+
+                await func.Should().ThrowAsync<OperationCanceledException>();
+            }
+
+            [Test, Auto]
+            public async Task ShouldNotThrowIfNotCancelled(
+                Bucket bucket,
+                [Target] DefaultBucketService service,
+                CancellationToken cancellationToken
+            )
+            {
+                var httpResponse = new HttpResponseMessage();
+
+                Func<Task> func = () => service.MergeBucketIds(bucket, httpResponse, cancellationToken);
+
+                await func.Should().NotThrowAsync<OperationCanceledException>();
+            }
+
+            [Test, Auto]
+            public async Task ShouldNotThrowIfHeaderIsNotPresent(
+                string remoteId,
+                Bucket bucket,
+                [Target] DefaultBucketService service,
+                CancellationToken cancellationToken
+            )
+            {
+                var httpResponse = new HttpResponseMessage();
+
+                Func<Task> func = () => service.MergeBucketIds(bucket, httpResponse, cancellationToken);
+
+                await func.Should().NotThrowAsync();
+            }
+
+            [Test, Auto]
+            public async Task ShouldUpdateRemoteIdIfItAlreadyHasOne(
+                string existingId,
+                string newId,
+                Bucket bucket,
+                [Target] DefaultBucketService service,
+                CancellationToken cancellationToken
+            )
+            {
+                bucket.RemoteId = existingId;
+                var httpResponse = new HttpResponseMessage();
+                httpResponse.Headers.Add("x-ratelimit-bucket", new[] { newId });
+
+                var result = await service.MergeBucketIds(bucket, httpResponse, cancellationToken);
+
+                result.RemoteId.Should().Be(newId);
+            }
+
+            [Test, Auto]
+            public async Task ShouldAddEndpointToExistingBucketIfOneExistsWithTheGivenRemoteId(
+                string remoteId,
+                Bucket bucket,
+                Bucket existingBucket,
+                [Frozen] IBucketRepository repository,
+                [Target] DefaultBucketService service,
+                CancellationToken cancellationToken
+            )
+            {
+                bucket.RemoteId = null;
+                bucket.Endpoints = (long)ChannelEndpoint.CreateMessage;
+                bucket.ApiCategory = 'c';
+                existingBucket.Endpoints = (long)ChannelEndpoint.DeleteMessage;
+                existingBucket.ApiCategory = 'c';
+
+                var httpResponse = new HttpResponseMessage();
+                httpResponse.Headers.Add("x-ratelimit-bucket", new[] { remoteId });
+
+                repository.FindByRemoteId(Any<string>(), Any<CancellationToken>()).Returns(existingBucket);
+                var result = await service.MergeBucketIds(bucket, httpResponse, cancellationToken);
+
+                result.Should().Be(existingBucket);
+                existingBucket.HasEndpoint(ChannelEndpoint.CreateMessage).Should().BeTrue();
+                await repository.Received().FindByRemoteId(Is(remoteId), Is(cancellationToken));
+            }
+
+            [Test, Auto]
+            public async Task ShouldRemoveNewBucketIfOneAlreadyExistsWithTheGivenRemoteId(
+                string remoteId,
+                Bucket bucket,
+                Bucket existingBucket,
+                [Frozen] IBucketRepository repository,
+                [Target] DefaultBucketService service,
+                CancellationToken cancellationToken
+            )
+            {
+                bucket.RemoteId = null;
+                bucket.Endpoints = (long)ChannelEndpoint.CreateMessage;
+                bucket.ApiCategory = 'c';
+                existingBucket.Endpoints = (long)ChannelEndpoint.DeleteMessage;
+                existingBucket.ApiCategory = 'c';
+
+                var httpResponse = new HttpResponseMessage();
+                httpResponse.Headers.Add("x-ratelimit-bucket", new[] { remoteId });
+
+                repository.FindByRemoteId(Any<string>(), Any<CancellationToken>()).Returns(existingBucket);
+                await service.MergeBucketIds(bucket, httpResponse, cancellationToken);
+
+                repository.Received().Remove(Is(bucket));
+            }
+
+            [Test, Auto]
+            public async Task ShouldUpdateTheNewBucketsRemoteIdIfNoExistingBucketWithRemoteId(
+                string remoteId,
+                Bucket bucket,
+                Bucket existingBucket,
+                [Frozen] IBucketRepository repository,
+                [Target] DefaultBucketService service,
+                CancellationToken cancellationToken
+            )
+            {
+                bucket.RemoteId = null;
+                bucket.Endpoints = (long)ChannelEndpoint.CreateMessage;
+                bucket.ApiCategory = 'c';
+                existingBucket.Endpoints = (long)ChannelEndpoint.DeleteMessage;
+                existingBucket.ApiCategory = 'c';
+
+                var httpResponse = new HttpResponseMessage();
+                httpResponse.Headers.Add("x-ratelimit-bucket", new[] { remoteId });
+
+                repository.FindByRemoteId(Any<string>(), Any<CancellationToken>()).Returns((Bucket)null!);
+                var result = await service.MergeBucketIds(bucket, httpResponse, cancellationToken);
+
+                result.Should().Be(bucket);
+                result.RemoteId.Should().Be(remoteId);
+                await repository.Received().FindByRemoteId(Is(remoteId), Is(cancellationToken));
+            }
+        }
+
+        [TestFixture]
+        public class UpdateBucketResetAfterTests
+        {
+            [Test, Auto]
+            public void ShouldUpdateResetAfterFromHeaderValue(
+                Bucket bucket,
+                [Target] DefaultBucketService service
+            )
+            {
+                var response = new HttpResponseMessage();
+                response.Headers.Add("x-ratelimit-reset", new[] { "1621277586" });
+
+                service.UpdateBucketResetAfter(bucket, response);
+
+                bucket.ResetAfter.Should().Be(DateTimeOffset.FromUnixTimeSeconds(1621277586));
+            }
+
+            [Test, Auto]
+            public void ShouldNotThrowIfHeaderNotPresent(
+                Bucket bucket,
+                [Target] DefaultBucketService service
+            )
+            {
+                var response = new HttpResponseMessage();
+
+                Action func = () => service.UpdateBucketResetAfter(bucket, response);
+
+                func.Should().NotThrow();
+            }
+
+            [Test, Auto]
+            public void ShouldNotThrowIfHeaderValueIsNotANumber(
+                Bucket bucket,
+                [Target] DefaultBucketService service
+            )
+            {
+                var response = new HttpResponseMessage();
+                response.Headers.Add("x-ratelimit-reset", new[] { "asdf" });
+
+                Action func = () => service.UpdateBucketResetAfter(bucket, response);
+
+                func.Should().NotThrow();
+            }
+        }
+
+        [TestFixture]
+        public class UpdateBucketsHitsRemainingTests
+        {
+            [Test, Auto]
+            public void ShouldUpdateHitsRemaining(
+                Bucket bucket,
+                [Target] DefaultBucketService service
+            )
+            {
+                var response = new HttpResponseMessage();
+                response.Headers.Add("x-ratelimit-remaining", new[] { "12" });
+
+                service.UpdateBucketHitsRemaining(bucket, response);
+
+                bucket.HitsRemaining.Should().Be(12);
+            }
+
+            [Test, Auto]
+            public void ShouldNotThrowIfHeaderNotPresent(
+                Bucket bucket,
+                [Target] DefaultBucketService service
+            )
+            {
+                var response = new HttpResponseMessage();
+
+                Action func = () => service.UpdateBucketHitsRemaining(bucket, response);
+
+                func.Should().NotThrow();
+            }
+
+            [Test, Auto]
+            public void ShouldNotThrowIfHeaderValueIsNotANumber(
+                Bucket bucket,
+                [Target] DefaultBucketService service
+            )
+            {
+                var response = new HttpResponseMessage();
+                response.Headers.Add("x-ratelimit-remaining", new[] { "asdf" });
+
+                Action func = () => service.UpdateBucketHitsRemaining(bucket, response);
+
+                func.Should().NotThrow();
             }
         }
     }

--- a/tests/Adapter/Requests/Services/DefaultBucketServiceTests.cs
+++ b/tests/Adapter/Requests/Services/DefaultBucketServiceTests.cs
@@ -286,12 +286,12 @@ namespace Brighid.Discord.Adapter.Requests
                 var httpResponse = new HttpResponseMessage();
                 httpResponse.Headers.Add("x-ratelimit-bucket", new[] { remoteId });
 
-                repository.FindByRemoteId(Any<string>(), Any<CancellationToken>()).Returns(existingBucket);
+                repository.FindByRemoteIdAndMajorParameters(Any<string>(), Any<MajorParameters>(), Any<CancellationToken>()).Returns(existingBucket);
                 var result = await service.MergeBucketIds(bucket, httpResponse, cancellationToken);
 
                 result.Should().Be(existingBucket);
                 existingBucket.HasEndpoint(ChannelEndpoint.CreateMessage).Should().BeTrue();
-                await repository.Received().FindByRemoteId(Is(remoteId), Is(cancellationToken));
+                await repository.Received().FindByRemoteIdAndMajorParameters(Is(remoteId), Is(bucket.MajorParameters), Is(cancellationToken));
             }
 
             [Test, Auto]
@@ -313,10 +313,10 @@ namespace Brighid.Discord.Adapter.Requests
                 var httpResponse = new HttpResponseMessage();
                 httpResponse.Headers.Add("x-ratelimit-bucket", new[] { remoteId });
 
-                repository.FindByRemoteId(Any<string>(), Any<CancellationToken>()).Returns(existingBucket);
+                repository.FindByRemoteIdAndMajorParameters(Any<string>(), Any<MajorParameters>(), Any<CancellationToken>()).Returns(existingBucket);
                 await service.MergeBucketIds(bucket, httpResponse, cancellationToken);
 
-                repository.Received().Remove(Is(bucket));
+                await repository.Received().Remove(Is(bucket), Is(cancellationToken));
             }
 
             [Test, Auto]
@@ -338,12 +338,12 @@ namespace Brighid.Discord.Adapter.Requests
                 var httpResponse = new HttpResponseMessage();
                 httpResponse.Headers.Add("x-ratelimit-bucket", new[] { remoteId });
 
-                repository.FindByRemoteId(Any<string>(), Any<CancellationToken>()).Returns((Bucket)null!);
+                repository.FindByRemoteIdAndMajorParameters(Any<string>(), Any<MajorParameters>(), Any<CancellationToken>()).Returns((Bucket)null!);
                 var result = await service.MergeBucketIds(bucket, httpResponse, cancellationToken);
 
                 result.Should().Be(bucket);
                 result.RemoteId.Should().Be(remoteId);
-                await repository.Received().FindByRemoteId(Is(remoteId), Is(cancellationToken));
+                await repository.Received().FindByRemoteIdAndMajorParameters(Is(remoteId), Is(bucket.MajorParameters), Is(cancellationToken));
             }
         }
 

--- a/tests/Adapter/Requests/Services/DefaultRequestInvokerTests.cs
+++ b/tests/Adapter/Requests/Services/DefaultRequestInvokerTests.cs
@@ -121,6 +121,57 @@ namespace Brighid.Discord.Adapter.Requests
             }
 
             [Test, Auto]
+            public async Task ShouldMergeBucketIds(
+                RequestMessage request,
+                [Frozen] Bucket bucket,
+                [Frozen] HttpResponseMessage responseMessage,
+                [Frozen, Substitute] IBucketService bucketService,
+                [Frozen, Substitute] HttpMessageInvoker client,
+                [Frozen, Substitute] IUrlBuilder urlBuilder,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                await invoker.Invoke(request, cancellationToken);
+
+                await bucketService.Received().MergeBucketIds(Is(bucket), Is(responseMessage), Is(cancellationToken));
+            }
+
+            [Test, Auto]
+            public async Task ShouldUpdateBucketHitsRemaining(
+                RequestMessage request,
+                [Frozen] Bucket bucket,
+                [Frozen] HttpResponseMessage responseMessage,
+                [Frozen, Substitute] IBucketService bucketService,
+                [Frozen, Substitute] HttpMessageInvoker client,
+                [Frozen, Substitute] IUrlBuilder urlBuilder,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                await invoker.Invoke(request, cancellationToken);
+
+                bucketService.Received().UpdateBucketHitsRemaining(Is(bucket), Is(responseMessage));
+            }
+
+            [Test, Auto]
+            public async Task ShouldUpdateBucketResetAfter(
+                RequestMessage request,
+                [Frozen] Bucket bucket,
+                [Frozen] HttpResponseMessage responseMessage,
+                [Frozen, Substitute] IBucketService bucketService,
+                [Frozen, Substitute] HttpMessageInvoker client,
+                [Frozen, Substitute] IUrlBuilder urlBuilder,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                await invoker.Invoke(request, cancellationToken);
+
+                bucketService.Received().UpdateBucketResetAfter(Is(bucket), Is(responseMessage));
+            }
+
+            [Test, Auto]
             public async Task ShouldSendRequestWithNoBody(
                 RequestMessage request,
                 [Frozen, Substitute] HttpMessageInvoker client,
@@ -156,6 +207,26 @@ namespace Brighid.Discord.Adapter.Requests
 
                 await client.Received().SendAsync(Any<HttpRequestMessage>(), Is(cancellationToken));
                 await relay.Received().Complete(Is(request), Is(statusCode), Is(response), Is(cancellationToken));
+            }
+
+            [Test, Auto]
+            public async Task ShouldSaveChangesToTheBucket(
+                string response,
+                RequestMessage request,
+                [Frozen] HttpStatusCode statusCode,
+                [Frozen] Bucket bucket,
+                [Frozen] HttpResponseMessage httpResponse,
+                [Frozen, Substitute] HttpMessageInvoker client,
+                [Frozen, Substitute] IBucketRepository repository,
+                [Target] DefaultRequestInvoker invoker,
+                CancellationToken cancellationToken
+            )
+            {
+                httpResponse.Content = new StringContent(response);
+                request.RequestDetails = new Request(ChannelEndpoint.CreateMessage) { RequestBody = null };
+                await invoker.Invoke(request, cancellationToken);
+
+                await repository.Received().Save(Is(bucket), Is(cancellationToken));
             }
 
             [Test, Auto]


### PR DESCRIPTION
Provides methods for updating buckets on the bucket service, including:

- Merging remote bucket IDs into the bucket that was used, or an existing bucket if one is found with that bucket ID.
- Updating Hits Remaining
- Updating Reset After