### PR TITLE
BRGD-78 Message Attributes

### DIFF
--- a/src/Adapter/Events/Controllers/MessageCreateEventController.cs
+++ b/src/Adapter/Events/Controllers/MessageCreateEventController.cs
@@ -50,7 +50,7 @@ namespace Brighid.Discord.Adapter.Events
             if (await userService.IsUserRegistered(@event.Message.Author, cancellationToken))
             {
                 logger.LogInformation("Message author is registered, emitting message.");
-                await emitter.Emit(@event.Message, cancellationToken);
+                await emitter.Emit(@event.Message, @event.Message.ChannelId, cancellationToken);
             }
         }
     }

--- a/src/Adapter/Messages/Services/IMessageEmitter.cs
+++ b/src/Adapter/Messages/Services/IMessageEmitter.cs
@@ -1,6 +1,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+using Brighid.Discord.Models;
+
 namespace Brighid.Discord.Adapter.Messages
 {
     /// <summary>
@@ -13,8 +15,9 @@ namespace Brighid.Discord.Adapter.Messages
         /// </summary>
         /// <typeparam name="TMessageType">The type of message to emit.</typeparam>
         /// <param name="message">The message to emit.</param>
+        /// <param name="channelId">ID of the channel that the message originated from.</param>
         /// <param name="cancellationToken">Token used to cancel the task.</param>
         /// <returns>The resulting task.</returns>
-        Task Emit<TMessageType>(TMessageType message, CancellationToken cancellationToken = default);
+        Task Emit<TMessageType>(TMessageType message, Snowflake channelId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Adapter/Messages/Services/SnsMessageEmitter.cs
+++ b/src/Adapter/Messages/Services/SnsMessageEmitter.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 
+using Brighid.Discord.Models;
 using Brighid.Discord.Serialization;
 
 using Microsoft.Extensions.Logging;
@@ -17,6 +19,8 @@ namespace Brighid.Discord.Adapter.Messages
     [LogCategory("Message Emitter")]
     public class SnsMessageEmitter : IMessageEmitter
     {
+        private static readonly MessageAttributeValue SourceSystemAttribute = new() { DataType = "String", StringValue = "discord" };
+
         private readonly IAmazonSimpleNotificationService snsClient;
 
         private readonly SnsMessageEmitterOptions options;
@@ -50,14 +54,25 @@ namespace Brighid.Discord.Adapter.Messages
         /// </summary>
         /// <typeparam name="TMessageType">The type of message to emit.</typeparam>
         /// <param name="message">The message to emit.</param>
+        /// <param name="channelId">ID of the channel the message originated from.</param>
         /// <param name="cancellationToken">Token used to cancel the task.</param>
         /// <returns>The resulting task.</returns>
-        public async Task Emit<TMessageType>(TMessageType message, CancellationToken cancellationToken = default)
+        public async Task Emit<TMessageType>(TMessageType message, Snowflake channelId, CancellationToken cancellationToken = default)
         {
             using var scope = logger.BeginScope("{@ApiCall}", "sns:Publish");
 
             var serializedMessage = await serializer.Serialize(message, cancellationToken);
-            var request = new PublishRequest { TopicArn = options.TopicArn, Message = serializedMessage };
+            var request = new PublishRequest
+            {
+                TopicArn = options.TopicArn,
+                Message = serializedMessage,
+                MessageAttributes = new Dictionary<string, MessageAttributeValue>
+                {
+                    ["Brighid.SourceSystem"] = SourceSystemAttribute,
+                    ["Brighid.SourceId"] = new MessageAttributeValue { DataType = "String", StringValue = channelId },
+                },
+            };
+
             logger.LogInformation("Sending request: {@request}", request);
 
             var response = await snsClient.PublishAsync(request, cancellationToken);

--- a/tests/Adapter/Events/Controllers/MessageCreateEventControllerTests.cs
+++ b/tests/Adapter/Events/Controllers/MessageCreateEventControllerTests.cs
@@ -39,13 +39,14 @@ namespace Brighid.Discord.Adapter.Events
                 Func<Task> func = () => controller.Handle(@event, cancellationToken);
 
                 await func.Should().ThrowAsync<OperationCanceledException>();
-                await emitter.DidNotReceive().Emit(Any<Message>(), Any<CancellationToken>());
+                await emitter.DidNotReceive().Emit(Any<Message>(), Any<Snowflake>(), Any<CancellationToken>());
             }
 
             [Test, Auto]
             public async Task ShouldEmitMessageIfUserIsRegistered(
                 string content,
                 Snowflake userId,
+                Snowflake channelId,
                 [Frozen, Substitute] IMessageEmitter emitter,
                 [Frozen, Substitute] IUserService userService,
                 [Target] MessageCreateEventController controller
@@ -53,14 +54,14 @@ namespace Brighid.Discord.Adapter.Events
             {
                 var cancellationToken = new CancellationToken(false);
                 var author = new User { Id = userId };
-                var message = new Message { Content = content, Author = author };
+                var message = new Message { Content = content, Author = author, ChannelId = channelId };
                 var @event = new MessageCreateEvent { Message = message };
 
                 userService.IsUserRegistered(Any<User>(), Any<CancellationToken>()).Returns(true);
 
                 await controller.Handle(@event, cancellationToken);
 
-                await emitter.Received().Emit(Is(message), Is(cancellationToken));
+                await emitter.Received().Emit(Is(message), Is(channelId), Is(cancellationToken));
                 await userService.Received().IsUserRegistered(Is(author), Is(cancellationToken));
             }
 
@@ -68,6 +69,7 @@ namespace Brighid.Discord.Adapter.Events
             public async Task ShouldNotEmitMessageIfUserIsNotRegistered(
                 string content,
                 Snowflake userId,
+                Snowflake channelId,
                 [Frozen, Substitute] IMessageEmitter emitter,
                 [Frozen, Substitute] IUserService userService,
                 [Target] MessageCreateEventController controller
@@ -75,14 +77,14 @@ namespace Brighid.Discord.Adapter.Events
             {
                 var cancellationToken = new CancellationToken(false);
                 var author = new User { Id = userId };
-                var message = new Message { Content = content, Author = author };
+                var message = new Message { Content = content, Author = author, ChannelId = channelId };
                 var @event = new MessageCreateEvent { Message = message };
 
                 userService.IsUserRegistered(Any<User>(), Any<CancellationToken>()).Returns(false);
 
                 await controller.Handle(@event, cancellationToken);
 
-                await emitter.DidNotReceive().Emit(Is(message), Is(cancellationToken));
+                await emitter.DidNotReceive().Emit(Is(message), Is(channelId), Is(cancellationToken));
                 await userService.Received().IsUserRegistered(Is(author), Is(cancellationToken));
             }
 


### PR DESCRIPTION
Now sending messages with two attributes:

- Brighid.SourceSystem - (system the message originates from) set to discord
- Brighid.SourceId - (id of the channel/thread/etc. the message is from within the source system) set to channelId

