### PR TITLE
BRGD-84 Response Handler Invoke Permission

### DIFF
--- a/deploy/brighid-discord-adapter.template.yml
+++ b/deploy/brighid-discord-adapter.template.yml
@@ -209,3 +209,11 @@ Resources:
       TopicArn: !ImportValue brighid-infrastructure:ResponseTopicArn
       FilterPolicy:
         Brighid.SourceSystem: [discord]
+
+  ResponseHandlerPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt ResponseHandler.Arn
+      Principal: sns.amazonaws.com
+      SourceArn: !ImportValue brighid-infrastructure:ResponseTopicArn


### PR DESCRIPTION
This adds a lambda permission resource to allow the response SNS topic to invoke the response handler.