### PR TITLE
BRGD-88 Enable Deployment Circuit Breaker

### DIFF
--- a/deploy/brighid-discord-adapter.template.yml
+++ b/deploy/brighid-discord-adapter.template.yml
@@ -149,6 +149,9 @@ Resources:
       DeploymentConfiguration:
         MinimumHealthyPercent: 1
         MaximumPercent: 200
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
 
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition


### PR DESCRIPTION
Turns on the deployment circuit breaker so that failed ECS deployments automatically rollback before the stabilization timeout.