### PR TITLE
BRGD-96 Update Registration Link

### DIFF
--- a/deploy/brighid-discord-adapter.template.yml
+++ b/deploy/brighid-discord-adapter.template.yml
@@ -25,6 +25,10 @@ Parameters:
     Type: String
     Description: URI of the identity server.
 
+  RegistrationUrl:
+    Type: String
+    Description: URL that users can register and link their Discord account at.
+
   DatabaseName:
     Type: String
     Description: The name of the database to use
@@ -209,6 +213,8 @@ Resources:
               Value: !Ref ClientId
             - Name: Encrypted__Adapter__ClientSecret
               Value: !Ref ClientSecret
+            - Name: Adapter__RegistrationUrl
+              Value: !Ref RegistrationUrl
             - Name: Adapter__OAuth2RedirectUri
               Value: !Sub https://${DomainName}/oauth2/callback
 

--- a/deploy/params/dev.json
+++ b/deploy/params/dev.json
@@ -4,6 +4,7 @@
   "AdapterToken": "AQICAHjCPp/4JJqnSjdP1A4JZ+E3yC2Gqmk9GshiMiqu57jujwF3IBfwfHUC5xJjj9LciUbsAAAAnTCBmgYJKoZIhvcNAQcGoIGMMIGJAgEAMIGDBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDKkfYweUsr4WCtNlIgIBEIBWBij3YkYY8LidrA7tYv6f4cOFx7STWOOUQgg/N2KAh8Nrl35AyBLbyt8xx3LLeEDSG0jNuofavmdcnF+gd00ah8dlVAcNdKTp63X4AeM/49j/Fz6MPQ0=",
   "MetricsNamespace": "BrighidDiscordAdapter",
   "IdentityServerUri": "http://identity.dev.brigh.id",
+  "RegistrationUrl": "https://identity.dev.brigh.id/account/link/discord",
   "DatabaseUser": "brighid-discord",
   "DatabaseName": "brighid-discord",
   "DatabasePassword": "AQICAHjCPp/4JJqnSjdP1A4JZ+E3yC2Gqmk9GshiMiqu57jujwFTov91m7LK3hkwJI3An32uAAAAbzBtBgkqhkiG9w0BBwagYDBeAgEAMFkGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMIxkKMyEvY/io7eRCAgEQgCw4hT/q4b4D40Gl4ajJ2pU9xaoZkvzTT/A3q/FNzxyeXRuAK4/u0gEu6BLkHA==",

--- a/deploy/params/prod.json
+++ b/deploy/params/prod.json
@@ -4,6 +4,7 @@
   "AdapterToken": "AQICAHj/2SUStzyXNMLx0/GX2lnjChwPoR4BUvoYRIybQNwYyQH7c6I9/U8oOsaZnOZxwZXhAAAAnTCBmgYJKoZIhvcNAQcGoIGMMIGJAgEAMIGDBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDKlVr9CIwyw+o0IQqgIBEIBWuCPGRVDCqewO1wSgOYqBRzWi/DsN+BICBxwshfADcw/KvrIlfQizoG3LSDLQ5/lmP/69EkTViLgjLUujdGyKJRgfSAEbw7W9+wQi7Iu3xWXC0G4gTBM=",
   "MetricsNamespace": "BrighidDiscordAdapter",
   "IdentityServerUri": "http://identity.brigh.id",
+  "RegistrationUrl": "https://identity.brigh.id/account/link/discord",
   "DatabaseUser": "brighid-discord",
   "DatabaseName": "brighid-discord",
   "DatabasePassword": "AQICAHj/2SUStzyXNMLx0/GX2lnjChwPoR4BUvoYRIybQNwYyQGYDlyJcWxnm2HX1OEFg3qrAAAAbzBtBgkqhkiG9w0BBwagYDBeAgEAMFkGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMFN8ERCNLIML21BezAgEQgCwiVhQ6CvdQJnvtv3MX0cBRvooKZLZs2T4za+67ujRvJdXEjXr8z2Jb4CV6Ag==",

--- a/src/Adapter/AdapterOptions.cs
+++ b/src/Adapter/AdapterOptions.cs
@@ -32,6 +32,11 @@ namespace Brighid.Discord.Adapter
         public string ClientSecret { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets the Registration URL sent to unregistered users on mention.
+        /// </summary>
+        public string RegistrationUrl { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets the OAuth2 User Info Endpoint.
         /// </summary>
         public Uri OAuth2UserInfoEndpoint { get; set; } = new Uri("https://discord.com/api/users/@me");

--- a/src/Adapter/Events/Controllers/MessageCreateEventController.cs
+++ b/src/Adapter/Events/Controllers/MessageCreateEventController.cs
@@ -25,7 +25,7 @@ namespace Brighid.Discord.Adapter.Events
         private readonly IDiscordUserClient discordUserClient;
         private readonly IDiscordChannelClient discordChannelClient;
         private readonly IStringLocalizer<Strings> strings;
-        private readonly IdentityOptions identityOptions;
+        private readonly AdapterOptions adapterOptions;
         private readonly IGatewayService gateway;
         private readonly IMetricReporter reporter;
         private readonly ILogger<MessageCreateEventController> logger;
@@ -38,7 +38,7 @@ namespace Brighid.Discord.Adapter.Events
         /// <param name="discordUserClient">Client used to send User API requests to Discord.</param>
         /// <param name="discordChannelClient">Client used to send Channel API requests to Discord.</param>
         /// <param name="strings">Localizer service for retrieving strings.</param>
-        /// <param name="identityOptions">Options to use for the identity service.</param>
+        /// <param name="adapterOptions">Options to use for the adapter.</param>
         /// <param name="gateway">Gateway that discord sends events through.</param>
         /// <param name="reporter">Reporter to report metrics to.</param>
         /// <param name="logger">Logger used to log information to some destination(s).</param>
@@ -48,7 +48,7 @@ namespace Brighid.Discord.Adapter.Events
             IDiscordUserClient discordUserClient,
             IDiscordChannelClient discordChannelClient,
             IStringLocalizer<Strings> strings,
-            IOptions<IdentityOptions> identityOptions,
+            IOptions<AdapterOptions> adapterOptions,
             IGatewayService gateway,
             IMetricReporter reporter,
             ILogger<MessageCreateEventController> logger
@@ -59,7 +59,7 @@ namespace Brighid.Discord.Adapter.Events
             this.discordUserClient = discordUserClient;
             this.discordChannelClient = discordChannelClient;
             this.strings = strings;
-            this.identityOptions = identityOptions.Value;
+            this.adapterOptions = adapterOptions.Value;
             this.gateway = gateway;
             this.reporter = reporter;
             this.logger = logger;
@@ -82,7 +82,7 @@ namespace Brighid.Discord.Adapter.Events
             if (@event.Message.Mentions.Any(mention => mention.Id == gateway.BotId))
             {
                 var dmChannel = await discordUserClient.CreateDirectMessageChannel(@event.Message.Author.Id, cancellationToken);
-                var message = (string)strings["RegistrationGreeting", identityOptions.IdentityServerUri]!;
+                var message = (string)strings["RegistrationGreeting", adapterOptions.RegistrationUrl]!;
                 await discordChannelClient.CreateMessage(dmChannel.Id, message, cancellationToken);
             }
         }

--- a/tests/Adapter/Events/Controllers/MessageCreateEventControllerTests.cs
+++ b/tests/Adapter/Events/Controllers/MessageCreateEventControllerTests.cs
@@ -99,7 +99,7 @@ namespace Brighid.Discord.Adapter.Events
                 Snowflake botId,
                 Snowflake channelId,
                 [Frozen] Channel channel,
-                [Frozen] IdentityOptions options,
+                [Frozen] AdapterOptions options,
                 [Frozen] IStringLocalizer<Strings> strings,
                 [Frozen, Substitute] IDiscordUserClient userClient,
                 [Frozen, Substitute] IDiscordChannelClient channelClient,
@@ -121,7 +121,7 @@ namespace Brighid.Discord.Adapter.Events
                 await controller.Handle(@event, cancellationToken);
 
                 await userClient.Received().CreateDirectMessageChannel(Is(userId), Is(cancellationToken));
-                await channelClient.Received().CreateMessage(Is(channel.Id), Is<string>(strings["RegistrationGreeting", options.IdentityServerUri]!), Is(cancellationToken));
+                await channelClient.Received().CreateMessage(Is(channel.Id), Is<string>(strings["RegistrationGreeting", options.RegistrationUrl]!), Is(cancellationToken));
             }
 
             [Test, Auto]
@@ -131,7 +131,7 @@ namespace Brighid.Discord.Adapter.Events
                 Snowflake botId,
                 Snowflake channelId,
                 [Frozen] Channel channel,
-                [Frozen] IdentityOptions options,
+                [Frozen] AdapterOptions options,
                 [Frozen] IStringLocalizer<Strings> strings,
                 [Frozen, Substitute] IDiscordUserClient userClient,
                 [Frozen, Substitute] IDiscordChannelClient channelClient,
@@ -152,7 +152,7 @@ namespace Brighid.Discord.Adapter.Events
                 await controller.Handle(@event, cancellationToken);
 
                 await userClient.DidNotReceive().CreateDirectMessageChannel(Is(userId), Is(cancellationToken));
-                await channelClient.DidNotReceive().CreateMessage(Is(channel.Id), Is<string>(strings["RegistrationGreeting", options.IdentityServerUri]!), Is(cancellationToken));
+                await channelClient.DidNotReceive().CreateMessage(Is(channel.Id), Is<string>(strings["RegistrationGreeting", options.RegistrationUrl]!), Is(cancellationToken));
             }
 
             [Test, Auto]


### PR DESCRIPTION
This updates the registration link that gets sent to unregistered users.  It now correctly points to [identity url]/account/link/discord 