### PR TITLE
Don't Await Router.Route

### DIFF
--- a/src/Adapter/Gateway/Services/DefaultGatewayRxWorker.cs
+++ b/src/Adapter/Gateway/Services/DefaultGatewayRxWorker.cs
@@ -115,7 +115,7 @@ namespace Brighid.Discord.Adapter.Gateway
 
                 if (message.Data != null)
                 {
-                    await eventRouter.Route(message.Data, cancellationToken);
+                    _ = eventRouter.Route(message.Data, cancellationToken);
                 }
 
                 logger.LogInformation("Received message: {@message}", message);


### PR DESCRIPTION
If something happens inside the route call that throws an exception, this will cause the discord adapter to restart the entire gateway service.