### PR TITLE
BRGD-144 Update Log Group Name

### DIFF
--- a/deploy/brighid-discord-adapter.template.yml
+++ b/deploy/brighid-discord-adapter.template.yml
@@ -365,6 +365,7 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
+      LogGroupName: /brighid/discord-adapter
       RetentionInDays: 14
 
   ResponseHandler:


### PR DESCRIPTION
Updates the log group name to match the new convention (/brighid/{service-name})