### PR TITLE
Use Brighid Base Image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   adapter: 
-    image: mcr.microsoft.com/dotnet/sdk:5.0.401
+    image: mcr.microsoft.com/dotnet/sdk:5.0.401-alpine3.14
     entrypoint: dotnet watch --project src/Adapter run
     working_dir: /app
     restart: unless-stopped

--- a/src/Adapter/Dockerfile
+++ b/src/Adapter/Dockerfile
@@ -1,6 +1,6 @@
 ARG CONFIGURATION=Release
 
-FROM public.ecr.aws/micahhausler/alpine:3.14.0
+FROM public.ecr.aws/cythral/brighid/base:0.1.0
 ARG PROJECT_DIRECTORY
 ARG OUTPUT_DIRECTORY
 ARG CONFIGURATION
@@ -11,15 +11,9 @@ ENV \
 
 WORKDIR /app
 COPY ${PROJECT_DIRECTORY}/entrypoint.sh ${OUTPUT_DIRECTORY} ./
-COPY --from=public.ecr.aws/cythral/decrs /decrs /usr/local/bin/decrs
 
-RUN \
-    apk --no-cache add libcap gcompat runuser libgcc libstdc++ krb5 && \
-    rm -rf /var/cache/apk/* && \
-    chmod +x /app/entrypoint.sh && \
-    chmod 750 /usr/local/bin/decrs && \
-    setcap 'cap_net_bind_service=+ep' /app/Adapter && \
-    adduser --system --no-create-home brighid
+RUN chmod +x /app/entrypoint.sh && \
+    setcap 'cap_net_bind_service=+ep' /app/Adapter
 
 EXPOSE 80
 ENTRYPOINT /app/entrypoint.sh


### PR DESCRIPTION
- Converts Dockerfile to use Brighid Base Image (squashed version of alpine + utilities)
- Use alpine version of .NET SDK Image in docker-compose