### PR TITLE
Remove TFM from OutputPath

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,23 +4,32 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-    <RestoreLockedMode Condition="$(NUKEEPER) != 'true'">true</RestoreLockedMode>
-    <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)obj/$(MSBuildProjectName)/</BaseIntermediateOutputPath>
-    <BaseOutputPath>$(MSBuildThisFileDirectory)bin/$(MSBuildProjectName)/</BaseOutputPath>
-    <CompilerGeneratedFilesOutputPath>$(MSBuildThisFileDirectory)obj/$(MSBuildProjectName)/$(Configuration)</CompilerGeneratedFilesOutputPath>
+    <RestoreLockedMode>true</RestoreLockedMode>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)obj/$(MSBuildProjectName)/</BaseIntermediateOutputPath>
+    <BaseOutputPath>$(MSBuildThisFileDirectory)bin/$(MSBuildProjectName)/</BaseOutputPath>
+    <CompilerGeneratedFilesOutputPath>$(MSBuildThisFileDirectory)obj/$(MSBuildProjectName)/$(Configuration)</CompilerGeneratedFilesOutputPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Visible="false" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354" PrivateAssets="all" />
   </ItemGroup>

--- a/deploy/brighid-discord-adapter.template.yml
+++ b/deploy/brighid-discord-adapter.template.yml
@@ -380,7 +380,7 @@ Resources:
       Handler: ResponseHandler::Brighid.Discord.Adapter.ResponseHandler.Handler::Run
       Runtime: provided.al2
       Timeout: 30
-      CodeUri: ../bin/ResponseHandler/Release/net6.0/linux-x64/publish/
+      CodeUri: ../bin/ResponseHandler/Release/linux-x64/publish/
       MemorySize: 512
       Layers:
         - !Sub "{{resolve:ssm:/dotnet/${DotnetVersion}/layer-arn}}"


### PR DESCRIPTION
Removes the TFM from the outputpath so that the CloudFormation template doesn't need to be updated when the TFM updates.