### PR TITLE
Retag image via SDK

### DIFF
--- a/cicd/Cicd.DeployDriver/Host.cs
+++ b/cicd/Cicd.DeployDriver/Host.cs
@@ -72,8 +72,9 @@ namespace Brighid.Discord.Cicd.DeployDriver
             });
 
             var image = config!.Parameters!["Image"]!;
-            var repository = image.Split(':')[0];
-            var environmentTag = repository + ':' + options.Environment!.ToLower();
+            var imageParts = image.Split(':');
+            var repository = imageParts[0];
+            var version = imageParts[1];
 
             await Step($"Deploy template to {options.Environment}", async () =>
             {
@@ -91,42 +92,16 @@ namespace Brighid.Discord.Cicd.DeployDriver
                 await deployer.Deploy(context, cancellationToken);
             });
 
-            await Step("Login to ECR", async () =>
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                await ecrUtils.DockerLogin(repository, cancellationToken);
-            });
-
-            await Step("[Tag Image] Pulling Existing Image", async () =>
+            await Step("Retag Image", async () =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var pullCommand = new Command("docker pull", arguments: new[] { image });
-                await pullCommand.RunOrThrowError("Could not pull image from ECR.");
-            });
-
-            await Step("[Tag Image] Retag Image", async () =>
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var tagCommand = new Command("docker tag", arguments: new[] { image, environmentTag });
-                await tagCommand.RunOrThrowError("Could not retag image with environment.");
-            });
-
-            await Step("[Tag Image] Push Retagged Image", async () =>
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var pushCommand = new Command("docker push", arguments: new[] { environmentTag });
-                await pushCommand.RunOrThrowError("Could not push retagged image.");
-            });
-
-            await Step("[Cleanup] Logout of ECR", async () =>
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var command = new Command("docker logout", arguments: new[] { repository });
-                await command.RunOrThrowError("Could not logout of ECR.");
+                await ecrUtils.RetagImage(
+                    repository,
+                    version,
+                    options.Environment!.ToLower(),
+                    cancellationToken
+                );
             });
 
             lifetime.StopApplication();

--- a/cicd/Cicd.DeployDriver/Host.cs
+++ b/cicd/Cicd.DeployDriver/Host.cs
@@ -71,7 +71,7 @@ namespace Brighid.Discord.Cicd.DeployDriver
                 Console.WriteLine("Loaded configuration from S3.");
             });
 
-            var image = new Uri(config!.Parameters!["Image"]!);
+            var image = new Uri("https://" + config!.Parameters!["Image"]!);
             var registryId = image.Host[0..image.Host.IndexOf('.')];
             var imageParts = image.AbsolutePath[1..].Split(':');
             var repository = imageParts[0];

--- a/cicd/Cicd.DeployDriver/Host.cs
+++ b/cicd/Cicd.DeployDriver/Host.cs
@@ -71,8 +71,9 @@ namespace Brighid.Discord.Cicd.DeployDriver
                 Console.WriteLine("Loaded configuration from S3.");
             });
 
-            var image = config!.Parameters!["Image"]!;
-            var imageParts = image.Split(':');
+            var image = new Uri(config!.Parameters!["Image"]!);
+            var registryId = image.Host[0..image.Host.IndexOf('.')];
+            var imageParts = image.AbsolutePath[1..].Split(':');
             var repository = imageParts[0];
             var version = imageParts[1];
 
@@ -97,6 +98,7 @@ namespace Brighid.Discord.Cicd.DeployDriver
                 cancellationToken.ThrowIfCancellationRequested();
 
                 await ecrUtils.RetagImage(
+                    registryId,
                     repository,
                     version,
                     options.Environment!.ToLower(),

--- a/cicd/Cicd.Utils/EcrUtils.cs
+++ b/cicd/Cicd.Utils/EcrUtils.cs
@@ -55,12 +55,13 @@ namespace Brighid.Discord.Cicd.Utils
         /// <summary>
         /// Retags an image.
         /// </summary>
+        /// <param name="registry">The registry where the repository is located.</param>
         /// <param name="repository">The image repository.</param>
         /// <param name="oldTag">The existing tag of the image to retag.</param>
         /// <param name="newTag">Tag to retag the image with.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The resulting task.</returns>
-        public async Task RetagImage(string repository, string oldTag, string newTag, CancellationToken cancellationToken)
+        public async Task RetagImage(string registry, string repository, string oldTag, string newTag, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -70,6 +71,7 @@ namespace Brighid.Discord.Cicd.Utils
             var putImageRequest = new PutImageRequest
             {
                 ImageManifest = imageInfo.Images[0].ImageManifest,
+                RegistryId = registry,
                 RepositoryName = repository,
                 ImageTag = newTag,
             };

--- a/cicd/Cicd.Utils/EcrUtils.cs
+++ b/cicd/Cicd.Utils/EcrUtils.cs
@@ -66,7 +66,7 @@ namespace Brighid.Discord.Cicd.Utils
             cancellationToken.ThrowIfCancellationRequested();
 
             var oldTagId = new ImageIdentifier { ImageTag = oldTag };
-            var getImageRequest = new BatchGetImageRequest { RepositoryName = repository, ImageIds = new List<ImageIdentifier> { oldTagId } };
+            var getImageRequest = new BatchGetImageRequest { RegistryId = registry, RepositoryName = repository, ImageIds = new List<ImageIdentifier> { oldTagId } };
             var imageInfo = await ecr.BatchGetImageAsync(getImageRequest, cancellationToken);
             var putImageRequest = new PutImageRequest
             {


### PR DESCRIPTION
Retagging the image via the SDK instead of docker.  For some reason, retagging via docker changes the image digest.