### PR TITLE
BRGD-139 Clear Command Parameters Cache

### DIFF
--- a/cicd/Cicd.BuildDriver/packages.lock.json
+++ b/cicd/Cicd.BuildDriver/packages.lock.json
@@ -241,10 +241,10 @@
       },
       "Brighid.Commands.Client": {
         "type": "Transitive",
-        "resolved": "0.2.0-beta5",
-        "contentHash": "JAfRH/Vnx0WhclcRbQgy/UVPufQRCFFReHCWuMcaiRkaniKRNcaLA4zKsjNKWTWadAfeYQe4xxrErD0Y7djJ6Q==",
+        "resolved": "0.2.0-beta6",
+        "contentHash": "3MgyJ3l0MRoEwNHSwkLKdVnsotNWxxcyC4L1aMWmptfiICwJjJs/CLnVfnj0VDZj0Ikaxncs1o7rtCEgVx6tqA==",
         "dependencies": {
-          "Brighid.Identity.Client": "0.4.0",
+          "Brighid.Identity.Client": "0.5.0",
           "Microsoft.Extensions.Caching.Memory": "6.0.1",
           "Microsoft.Extensions.Configuration": "6.0.0",
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
@@ -2641,9 +2641,8 @@
         "dependencies": {
           "AWSSDK.CloudWatch": "3.7.3.27",
           "AWSSDK.SimpleNotificationService": "3.7.3.28",
-          "Brighid.Commands.Client": "0.2.0-beta5",
+          "Brighid.Commands.Client": "0.2.0-beta6",
           "Brighid.Discord.Core": "1.0.0",
-          "Brighid.Identity.Client": "0.5.0",
           "Destructurama.Attributed": "3.0.0",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "6.0.2",
           "Microsoft.EntityFrameworkCore": "6.0.2",

--- a/src/Adapter/Adapter.csproj
+++ b/src/Adapter/Adapter.csproj
@@ -11,8 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Brighid.Identity.Client" Version="0.5.0" />
-    <PackageReference Include="Brighid.Commands.Client" Version="0.2.0-beta5" />
+    <PackageReference Include="Brighid.Commands.Client" Version="0.2.0-beta6" />
     <PackageReference Include="AWSSDK.CloudWatch" Version="3.7.3.27" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.28" />
     <PackageReference Include="Destructurama.Attributed" Version="3.0.0" />

--- a/src/Adapter/Management/Controllers/CacheController.cs
+++ b/src/Adapter/Management/Controllers/CacheController.cs
@@ -1,5 +1,6 @@
 using System;
 
+using Brighid.Commands.Client;
 using Brighid.Discord.Adapter.Users;
 using Brighid.Identity.Client.Utils;
 
@@ -20,6 +21,7 @@ namespace Brighid.Discord.Adapter.Management
     {
         private readonly IUserIdCache userIdCache;
         private readonly ICacheUtils cacheUtils;
+        private readonly IBrighidCommandsCache commandsCache;
         private readonly ILogger<CacheController> logger;
 
         /// <summary>
@@ -27,15 +29,18 @@ namespace Brighid.Discord.Adapter.Management
         /// </summary>
         /// <param name="userIdCache">Cache to control user IDs.</param>
         /// <param name="cacheUtils">Utilities for working with the identity cache.</param>
+        /// <param name="commandsCache">Service for managing the Brighid Commands cache.</param>
         /// <param name="logger">Logger used to log info to some destination(s).</param>
         public CacheController(
             IUserIdCache userIdCache,
             ICacheUtils cacheUtils,
+            IBrighidCommandsCache commandsCache,
             ILogger<CacheController> logger
         )
         {
             this.userIdCache = userIdCache;
             this.cacheUtils = cacheUtils;
+            this.commandsCache = commandsCache;
             this.logger = logger;
         }
 
@@ -49,7 +54,22 @@ namespace Brighid.Discord.Adapter.Management
             userIdCache.Clear();
             cacheUtils.InvalidatePrimaryToken();
             cacheUtils.InvalidateAllUserTokens();
+            commandsCache.ClearAllParameters();
             logger.LogInformation("Cleared all internal caches.");
+
+            return Ok();
+        }
+
+        /// <summary>
+        /// Clear all caches related to a specific command.
+        /// </summary>
+        /// <param name="name">The name of the command to clear cache for.</param>
+        /// <returns>OK if successful.</returns>
+        [HttpDelete("commands/{name}")]
+        public StatusCodeResult ClearCommandSpecificCache(string name)
+        {
+            commandsCache.ClearParameters(name);
+            logger.LogInformation("Cleared command-specific cache for: {@name}", name);
 
             return Ok();
         }

--- a/src/Adapter/packages.lock.json
+++ b/src/Adapter/packages.lock.json
@@ -22,31 +22,17 @@
       },
       "Brighid.Commands.Client": {
         "type": "Direct",
-        "requested": "[0.2.0-beta5, )",
-        "resolved": "0.2.0-beta5",
-        "contentHash": "JAfRH/Vnx0WhclcRbQgy/UVPufQRCFFReHCWuMcaiRkaniKRNcaLA4zKsjNKWTWadAfeYQe4xxrErD0Y7djJ6Q==",
+        "requested": "[0.2.0-beta6, )",
+        "resolved": "0.2.0-beta6",
+        "contentHash": "3MgyJ3l0MRoEwNHSwkLKdVnsotNWxxcyC4L1aMWmptfiICwJjJs/CLnVfnj0VDZj0Ikaxncs1o7rtCEgVx6tqA==",
         "dependencies": {
-          "Brighid.Identity.Client": "0.4.0",
+          "Brighid.Identity.Client": "0.5.0",
           "Microsoft.Extensions.Caching.Memory": "6.0.1",
           "Microsoft.Extensions.Configuration": "6.0.0",
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Http": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "6.0.0"
-        }
-      },
-      "Brighid.Identity.Client": {
-        "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "s7/rGSmBpZy6/NFqngma89/Py+TDS2sKDbjd0gE09a+dch1659qQjIMFGE4lvl+r/HEwBjVNWEiGY4aWAO49jQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Caching.Memory": "6.0.1",
-          "Microsoft.Extensions.Configuration": "6.0.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "6.0.0",
-          "System.IdentityModel.Tokens.Jwt": "6.16.0"
         }
       },
       "Destructurama.Attributed": {
@@ -247,6 +233,19 @@
         "contentHash": "FRqvIuMLCqxrYAN84CyfCXmFWAhN7RbYs6O7Ungs7+d2yVSp8xApbGkXsUQugdS0u02CMqIFI2CMuYLkAUaafw==",
         "dependencies": {
           "AWSXRayRecorder.Core": "2.10.1"
+        }
+      },
+      "Brighid.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "0.5.0",
+        "contentHash": "s7/rGSmBpZy6/NFqngma89/Py+TDS2sKDbjd0gE09a+dch1659qQjIMFGE4lvl+r/HEwBjVNWEiGY4aWAO49jQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "6.0.1",
+          "Microsoft.Extensions.Configuration": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "6.0.0",
+          "System.IdentityModel.Tokens.Jwt": "6.16.0"
         }
       },
       "Humanizer.Core": {

--- a/tests/Adapter/Events/Controllers/MessageCreateEventControllerTests.cs
+++ b/tests/Adapter/Events/Controllers/MessageCreateEventControllerTests.cs
@@ -158,7 +158,7 @@ namespace Brighid.Discord.Adapter.Events
                 Received.InOrder(async () =>
                 {
                     await userService.Received().GetIdentityServiceUserId(Is(author), Is(cancellationToken));
-                    await commandsClient.Received().ParseAndExecuteCommandAsUser(Is(message.Content), Is(identityUserId.Id.ToString()), Is(cancellationToken));
+                    await commandsClient.Received().ParseAndExecuteCommandAsUser(Is(message.Content), Is(identityUserId.Id.ToString()), Is(channelId.ToString()), Is(cancellationToken));
                 });
             }
 
@@ -193,6 +193,7 @@ namespace Brighid.Discord.Adapter.Events
                     await commandsClient.Received().ParseAndExecuteCommandAsUser(
                         Is(@event.Message.Content),
                         Is(identityUserId.Id.ToString()),
+                        Is(channelId.ToString()),
                         Is(cancellationToken)
                     );
                     await channelClient.Received().CreateMessage(Is(channelId), Is(executeCommandResponse.Response), Is(cancellationToken));

--- a/tests/Adapter/Management/Controllers/CacheControllerTests.cs
+++ b/tests/Adapter/Management/Controllers/CacheControllerTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.NUnit3;
 
+using Brighid.Commands.Client;
 using Brighid.Discord.Adapter.Users;
 using Brighid.Identity.Client.Utils;
 
@@ -57,12 +58,51 @@ namespace Brighid.Discord.Adapter.Management
             }
 
             [Test, Auto]
+            public void ShouldClearTheCommandsCache(
+                [Frozen, Substitute] IBrighidCommandsCache commandsCache,
+                [Target] CacheController controller
+            )
+            {
+                controller.ClearAll();
+
+                commandsCache.Received().ClearAllParameters();
+            }
+
+            [Test, Auto]
             public void ShouldReturnOk(
                 [Frozen, Substitute] ICacheUtils cacheUtils,
                 [Target] CacheController controller
             )
             {
                 var result = controller.ClearAll();
+
+                result.StatusCode.Should().Be((int)HttpStatusCode.OK);
+            }
+        }
+
+        [TestFixture]
+        [Category("Unit")]
+        public class ClearCommandSpecificCacheTests
+        {
+            [Test, Auto]
+            public void ShouldClearCommandParameters(
+                string name,
+                [Frozen, Substitute] IBrighidCommandsCache commandsCache,
+                [Target] CacheController controller
+            )
+            {
+                controller.ClearCommandSpecificCache(name);
+
+                commandsCache.Received().ClearParameters(Is(name));
+            }
+
+            [Test, Auto]
+            public void ShouldReturnOk(
+                string name,
+                [Target] CacheController controller
+            )
+            {
+                var result = controller.ClearCommandSpecificCache(name);
 
                 result.StatusCode.Should().Be((int)HttpStatusCode.OK);
             }
@@ -81,7 +121,7 @@ namespace Brighid.Discord.Adapter.Management
             {
                 controller.ClearUserSpecificCache(identityId);
 
-                userIdCache.Received().RemoveByIdentityId(identityId);
+                userIdCache.Received().RemoveByIdentityId(Is(identityId));
             }
 
             [Test, Auto]

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -265,10 +265,10 @@
       },
       "Brighid.Commands.Client": {
         "type": "Transitive",
-        "resolved": "0.2.0-beta5",
-        "contentHash": "JAfRH/Vnx0WhclcRbQgy/UVPufQRCFFReHCWuMcaiRkaniKRNcaLA4zKsjNKWTWadAfeYQe4xxrErD0Y7djJ6Q==",
+        "resolved": "0.2.0-beta6",
+        "contentHash": "3MgyJ3l0MRoEwNHSwkLKdVnsotNWxxcyC4L1aMWmptfiICwJjJs/CLnVfnj0VDZj0Ikaxncs1o7rtCEgVx6tqA==",
         "dependencies": {
-          "Brighid.Identity.Client": "0.4.0",
+          "Brighid.Identity.Client": "0.5.0",
           "Microsoft.Extensions.Caching.Memory": "6.0.1",
           "Microsoft.Extensions.Configuration": "6.0.0",
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
@@ -2636,9 +2636,8 @@
         "dependencies": {
           "AWSSDK.CloudWatch": "3.7.3.27",
           "AWSSDK.SimpleNotificationService": "3.7.3.28",
-          "Brighid.Commands.Client": "0.2.0-beta5",
+          "Brighid.Commands.Client": "0.2.0-beta6",
           "Brighid.Discord.Core": "1.0.0",
-          "Brighid.Identity.Client": "0.5.0",
           "Destructurama.Attributed": "3.0.0",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "6.0.2",
           "Microsoft.EntityFrameworkCore": "6.0.2",


### PR DESCRIPTION
Clears command parameters cache in the ClearAll endpoint of the Cache Controller. 
Introduces a new endpoint for clearing specific command caches.