### PR TITLE
BRGD-236 Cache Expiry DNS Name Hotfix

### DIFF
--- a/cicd/template.yml
+++ b/cicd/template.yml
@@ -458,7 +458,7 @@ Resources:
         SubnetIds: !Split [",", !ImportValue cfn-utilities:PrivateSubnetIds]
       Environment:
         Variables:
-          Expirer__AdapterUrl: !Sub http://${DomainName}
+          Expirer__AdapterUrl: !Ref DomainName
           Identity__IdentityServerUri: !Sub http://${IdentityServerUri}
           Identity__ClientId: !GetAtt CacheExpirerIdentityApplication.Id
           Identity__ClientSecret: !GetAtt CacheExpirerIdentityApplication.EncryptedSecret

--- a/src/CacheExpirer/CacheExpirerOptions.cs
+++ b/src/CacheExpirer/CacheExpirerOptions.cs
@@ -1,5 +1,3 @@
-using System;
-
 using Lambdajection.Attributes;
 
 namespace Brighid.Discord.CacheExpirer
@@ -7,6 +5,6 @@ namespace Brighid.Discord.CacheExpirer
     [LambdaOptions(typeof(Handler), "Expirer")]
     public class CacheExpirerOptions
     {
-        public Uri AdapterUrl { get; set; } = new Uri("http://discord.brigh.id");
+        public string AdapterUrl { get; set; } = "discord.brigh.id";
     }
 }

--- a/src/CacheExpirer/Dns/DnsService.cs
+++ b/src/CacheExpirer/Dns/DnsService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
@@ -9,10 +8,10 @@ namespace Brighid.Discord.CacheExpirer
 {
     public class DnsService : IDnsService
     {
-        public async Task<IEnumerable<IPAddress>> GetIPAddresses(Uri host, CancellationToken cancellationToken)
+        public async Task<IEnumerable<IPAddress>> GetIPAddresses(string host, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return await Dns.GetHostAddressesAsync(host.DnsSafeHost, AddressFamily.Unspecified, cancellationToken);
+            return await Dns.GetHostAddressesAsync(host, AddressFamily.Unspecified, cancellationToken);
         }
     }
 }

--- a/src/CacheExpirer/Dns/IDnsService.cs
+++ b/src/CacheExpirer/Dns/IDnsService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
@@ -8,6 +7,6 @@ namespace Brighid.Discord.CacheExpirer
 {
     public interface IDnsService
     {
-        Task<IEnumerable<IPAddress>> GetIPAddresses(Uri host, CancellationToken cancellationToken);
+        Task<IEnumerable<IPAddress>> GetIPAddresses(string host, CancellationToken cancellationToken);
     }
 }

--- a/tests/CacheExpirer/HandlerTests.cs
+++ b/tests/CacheExpirer/HandlerTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,7 +35,7 @@ namespace Brighid.Discord.CacheExpirer
             {
                 request.Message.Type = CacheExpirationType.User;
                 request.Message.Id = userId;
-                dns.GetIPAddresses(Any<Uri>(), Any<CancellationToken>()).Returns(new[] { ip1, ip2 });
+                dns.GetIPAddresses(Any<string>(), Any<CancellationToken>()).Returns(new[] { ip1, ip2 });
 
                 await handler.Handle(request, cancellationToken);
 
@@ -61,7 +60,7 @@ namespace Brighid.Discord.CacheExpirer
             {
                 request.Message.Type = CacheExpirationType.Command;
                 request.Message.Id = command;
-                dns.GetIPAddresses(Any<Uri>(), Any<CancellationToken>()).Returns(new[] { ip1, ip2 });
+                dns.GetIPAddresses(Any<string>(), Any<CancellationToken>()).Returns(new[] { ip1, ip2 });
 
                 await handler.Handle(request, cancellationToken);
 


### PR DESCRIPTION
This fixes an issue where the lambda would fail since Uri.DnsSafeHost
throws an exception for 'relative uris,' and the AdapterUrl was being
detected as one.