### PR TITLE
Rename the Cache Manager Role

### DIFF
--- a/cicd/template.yml
+++ b/cicd/template.yml
@@ -476,7 +476,13 @@ Resources:
       Name: BrighidDiscordCacheExpirer
       Roles:
         - Basic
-        - CacheManager
+        - !GetAtt DiscordResponderRole.Name
+
+  CacheExpirerIdentityRole:
+    Type: Custom::IdentityRole
+    Properties:
+      ServiceToken: !ImportValue identity-resources:RoleResourceArn
+      Name: DiscordCacheManager
 
   AccountLinkStartUrl:
     Type: AWS::SSM::Parameter

--- a/src/Adapter/Management/Controllers/CacheController.cs
+++ b/src/Adapter/Management/Controllers/CacheController.cs
@@ -16,7 +16,7 @@ namespace Brighid.Discord.Adapter.Management
     /// Controls internal caches.
     /// </summary>
     [Route("/cache")]
-    [Authorize(Roles = "CacheManager")]
+    [Authorize(Roles = "DiscordCacheManager")]
     public class CacheController : Controller
     {
         private readonly IUserIdCache userIdCache;


### PR DESCRIPTION
Renames the Cache Manager Role and puts it under CF control.  Ran into an issue deploying to production because the CacheManager role didn't exist there.