### PR TITLE
Logging & Tracing Enhancements

### DIFF
--- a/cicd/template.yml
+++ b/cicd/template.yml
@@ -250,6 +250,7 @@ Resources:
               awslogs-group: !Ref LogGroup
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: brighid
+              awslogs-datetime-format: \[%Y-%m-%d %H:%M:%SZ\]
           Environment:
             - Name: AWS_XRAY_DAEMON_ADDRESS
               Value: xray:2000

--- a/global.json
+++ b/global.json
@@ -1,6 +1,5 @@
 {
   "sdk": {
-    "version": "6.0.200",
-    "rollForward": "latestMinor"
+    "version": "6.0.200"
   }
 }

--- a/src/Adapter/Events/Controllers/MessageCreateEventController.cs
+++ b/src/Adapter/Events/Controllers/MessageCreateEventController.cs
@@ -82,8 +82,8 @@ namespace Brighid.Discord.Adapter.Events
         public async Task Handle(MessageCreateEvent @event, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            using var scope = logger.BeginScope("{@Event}", nameof(MessageCreateEvent));
             using var trace = tracingService.StartTrace();
+            using var scope = logger.BeginScope("{@Event} {@TraceId}", nameof(MessageCreateEvent), trace.Id);
 
             tracingService.AddAnnotation("event", "incoming-message");
             tracingService.AddAnnotation("messageId", @event.Message.Id);
@@ -112,7 +112,7 @@ namespace Brighid.Discord.Adapter.Events
                     Color = 5763719,
                     Fields = new[]
                     {
-                        new Models.EmbedField { Name = "TraceId", Value = trace.Header },
+                        new Models.EmbedField { Name = "TraceId", Value = trace.Id },
                     },
                 };
         }

--- a/src/Adapter/Startup.cs
+++ b/src/Adapter/Startup.cs
@@ -46,7 +46,7 @@ namespace Brighid.Discord.Adapter
                 .ReadFrom.Configuration(configuration)
                 .Destructure.UsingAttributes()
                 .Enrich.FromLogContext()
-                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext:s}] {Message:lj} {Properties:j} {Exception}{NewLine}");
+                .WriteTo.Console(outputTemplate: "[{Timestamp:u}] [{Level:u3}] [{SourceContext:s}] {Message:lj} {Properties:j} {Exception}{NewLine}");
 
             loggerBuilder = environment.EnvironmentName switch
             {

--- a/src/Core/Tracing/Models/TraceContext.cs
+++ b/src/Core/Tracing/Models/TraceContext.cs
@@ -12,13 +12,16 @@ namespace Brighid.Discord.Tracing
         /// </summary>
         /// <param name="service">Service that created this context.</param>
         /// <param name="header">The tracing header to use to track a request.</param>
+        /// <param name="id">The trace identifier.</param>
         public TraceContext(
             ITracingService service,
-            string header
+            string header,
+            string id
         )
         {
             Service = service;
             Header = header;
+            Id = id;
         }
 
         /// <summary>
@@ -30,6 +33,11 @@ namespace Brighid.Discord.Tracing
         /// Gets or sets the trace header.
         /// </summary>
         public string Header { get; set; }
+
+        /// <summary>
+        /// Gets or sets the trace ID.
+        /// </summary>
+        public string Id { get; set; }
 
         /// <inheritdoc/>
         public void Dispose()

--- a/src/Core/Tracing/Services/AwsXRayTracingService.cs
+++ b/src/Core/Tracing/Services/AwsXRayTracingService.cs
@@ -50,7 +50,7 @@ namespace Brighid.Discord.Tracing
                 Sampled = sampled,
             };
 
-            context.Value = new TraceContext(this, traceHeader.ToString());
+            context.Value = new TraceContext(this, traceHeader.ToString(), traceHeader.RootTraceId);
             recorder.BeginSegment(
                 name: ServiceName,
                 traceId: traceId,

--- a/tests/Adapter/Events/Controllers/MessageCreateEventControllerTests.cs
+++ b/tests/Adapter/Events/Controllers/MessageCreateEventControllerTests.cs
@@ -296,7 +296,7 @@ namespace Brighid.Discord.Adapter.Events
                 await channelClient.Received().CreateMessage(
                     Is(channelId),
                     Is<CreateMessagePayload>(payload =>
-                        payload.Embed!.Value.Fields.Any(field => field.Name == "TraceId" && field.Value == traceContext.Header)
+                        payload.Embed!.Value.Fields.Any(field => field.Name == "TraceId" && field.Value == traceContext.Id)
                     ),
                     Is(cancellationToken)
                 );


### PR DESCRIPTION
- Adds awslogs-datetime-format so multiline log events are captured correctly by CloudWatch.
- Changed to UTC date time format for log events.
- Put Log Level and timestamp in separate blocks so they can be parsed separately by metric filters.