### PR TITLE
BRGD-262 Traffic Handoff After Startup

### DIFF
--- a/cicd/Cicd.BuildDriver/packages.lock.json
+++ b/cicd/Cicd.BuildDriver/packages.lock.json
@@ -264,8 +264,8 @@
       },
       "Brighid.Identity.Client": {
         "type": "Transitive",
-        "resolved": "0.6.2",
-        "contentHash": "Czxs0EhOQ0ZAbdLVjvgm4P97eM0PSFxFjgiMKr7JvlBZ7PZ5xctuT+nbEmpDjl84/5nGRC0seZBTdwTjVb23yQ==",
+        "resolved": "0.6.3",
+        "contentHash": "fL181rgJdBL5ZS7iiL7aDVWvQGWBK0AgI60kPM7AdVYcAr7yJD6IOeY+DyRy4/VcZveDea9lvwetEsiuhXLaTA==",
         "dependencies": {
           "Microsoft.Extensions.Caching.Memory": "6.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -2676,7 +2676,7 @@
           "AWSSDK.SimpleNotificationService": "3.7.3.77",
           "Brighid.Commands.Client": "0.2.0",
           "Brighid.Discord.Core": "1.0.0",
-          "Brighid.Identity.Client": "0.6.2",
+          "Brighid.Identity.Client": "0.6.3",
           "Destructurama.Attributed": "3.0.0",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "6.0.6",
           "Microsoft.EntityFrameworkCore": "6.0.6",

--- a/cicd/template.yml
+++ b/cicd/template.yml
@@ -201,7 +201,7 @@ Resources:
           Port: 80
       DesiredCount: 1
       DeploymentConfiguration:
-        MinimumHealthyPercent: 1
+        MinimumHealthyPercent: 100
         MaximumPercent: 200
         DeploymentCircuitBreaker:
           Enable: true

--- a/cicd/template.yml
+++ b/cicd/template.yml
@@ -258,6 +258,8 @@ Resources:
           Environment:
             - Name: AWS_XRAY_DAEMON_ADDRESS
               Value: xray:2000
+            - Name: AWS_XRAY_CONTEXT_MISSING
+              Value: LOG_ERROR
             - Name: Environment
               Value: !Ref EnvironmentName
             - Name: Encrypted__Adapter__Token

--- a/src/Adapter/Adapter.csproj
+++ b/src/Adapter/Adapter.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Brighid.Identity.Client" Version="0.6.2" />
+    <PackageReference Include="Brighid.Identity.Client" Version="0.6.3" />
     <PackageReference Include="Brighid.Commands.Client" Version="0.2.0" />
     <PackageReference Include="AWSSDK.ECS" Version="3.7.5.48" />
     <PackageReference Include="AWSSDK.CloudWatch" Version="3.7.4.30" />

--- a/src/Adapter/Events/Controllers/MessageCreateEventController.cs
+++ b/src/Adapter/Events/Controllers/MessageCreateEventController.cs
@@ -82,6 +82,8 @@ namespace Brighid.Discord.Adapter.Events
         public async Task Handle(MessageCreateEvent @event, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            gateway.ThrowIfNotReady();
+
             using var trace = tracingService.StartTrace();
             using var scope = logger.BeginScope("{@Event} {@TraceId}", nameof(MessageCreateEvent), trace.Id);
 

--- a/src/Adapter/Gateway/Services/DefaultGatewayService.cs
+++ b/src/Adapter/Gateway/Services/DefaultGatewayService.cs
@@ -88,6 +88,15 @@ namespace Brighid.Discord.Adapter.Gateway
             State |= GatewayState.Ready;
         }
 
+        /// <inheritdoc/>
+        public void ThrowIfNotReady()
+        {
+            if (!State.HasFlag(GatewayState.Ready))
+            {
+                throw new OperationCanceledException();
+            }
+        }
+
         /// <inheritdoc />
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {

--- a/src/Adapter/Gateway/Services/IGatewayService.cs
+++ b/src/Adapter/Gateway/Services/IGatewayService.cs
@@ -40,6 +40,11 @@ namespace Brighid.Discord.Adapter.Gateway
         void SetReadyState(bool ready);
 
         /// <summary>
+        /// Throw an exception if the gateway is not ready.
+        /// </summary>
+        void ThrowIfNotReady();
+
+        /// <summary>
         /// Restarts the gateway service.
         /// </summary>
         /// <param name="resume">Whether or not to resume after reconnecting.</param>

--- a/src/Adapter/Management/Models/Container.cs
+++ b/src/Adapter/Management/Models/Container.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Brighid.Discord.Adapter.Management
+{
+    /// <summary>
+    /// Represents information about a container within a task.
+    /// </summary>
+    public class Container
+    {
+        /// <summary>
+        /// Gets or sets the list of network interfaces attached to the task.
+        /// </summary>
+        [JsonPropertyName("Networks")]
+        public Network[] Networks { get; set; } = Array.Empty<Network>();
+    }
+}

--- a/src/Adapter/Management/Models/Network.cs
+++ b/src/Adapter/Management/Models/Network.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Brighid.Discord.Adapter.Management
+{
+    /// <summary>
+    /// Information about a task's network returned from the metadata endpoint v4.
+    /// </summary>
+    public class Network
+    {
+        /// <summary>
+        /// Gets or sets the list of ip addresses.
+        /// </summary>
+        [JsonPropertyName("IPv4Addresses")]
+        public string[] Ipv4Addresses { get; set; } = Array.Empty<string>();
+    }
+}

--- a/src/Adapter/Management/Models/TaskMetadata.cs
+++ b/src/Adapter/Management/Models/TaskMetadata.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Serialization;
 
 namespace Brighid.Discord.Adapter.Management
@@ -18,5 +19,11 @@ namespace Brighid.Discord.Adapter.Management
         /// </summary>
         [JsonPropertyName("Cluster")]
         public string Cluster { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the list of network interfaces attached to the task.
+        /// </summary>
+        [JsonPropertyName("Networks")]
+        public Network[] Networks { get; set; } = Array.Empty<Network>();
     }
 }

--- a/src/Adapter/Management/Models/TaskMetadata.cs
+++ b/src/Adapter/Management/Models/TaskMetadata.cs
@@ -21,9 +21,9 @@ namespace Brighid.Discord.Adapter.Management
         public string Cluster { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the list of network interfaces attached to the task.
+        /// Gets or sets a list of containers on the task.
         /// </summary>
-        [JsonPropertyName("Networks")]
-        public Network[] Networks { get; set; } = Array.Empty<Network>();
+        [JsonPropertyName("Containers")]
+        public Container[] Containers { get; set; } = Array.Empty<Container>();
     }
 }

--- a/src/Adapter/Management/Services/Node/INodeService.cs
+++ b/src/Adapter/Management/Services/Node/INodeService.cs
@@ -13,8 +13,9 @@ namespace Brighid.Discord.Adapter.Management
         /// <summary>
         /// Gets the IP address of the node.
         /// </summary>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The node's IP address.</returns>
-        IPAddress GetIpAddress();
+        Task<IPAddress> GetIpAddress(CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets the deployment ID.
@@ -26,8 +27,9 @@ namespace Brighid.Discord.Adapter.Management
         /// <summary>
         /// Get a list of peer nodes.
         /// </summary>
+        /// <param name="currentIp">IP address of the current node.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A list of peer adapter nodes.</returns>
-        Task<IEnumerable<NodeInfo>> GetPeers(CancellationToken cancellationToken);
+        Task<IEnumerable<NodeInfo>> GetPeers(IPAddress currentIp, CancellationToken cancellationToken);
     }
 }

--- a/src/Adapter/Management/Services/Node/NodeService.cs
+++ b/src/Adapter/Management/Services/Node/NodeService.cs
@@ -58,7 +58,7 @@ namespace Brighid.Discord.Adapter.Management
 
             return taskMetadata == null
                     ? IPAddress.None
-                    : IPAddress.Parse(taskMetadata.Networks[0].Ipv4Addresses[0]);
+                    : IPAddress.Parse(taskMetadata.Containers[0].Networks[0].Ipv4Addresses[0]);
         }
 
         /// <inheritdoc />

--- a/src/Adapter/Management/Services/Node/NodeService.cs
+++ b/src/Adapter/Management/Services/Node/NodeService.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http.Json;
-using System.Net.NetworkInformation;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,7 +12,6 @@ using Amazon.ECS.Model;
 using Microsoft.Extensions.Options;
 
 using HttpClient = System.Net.Http.HttpClient;
-using NetworkInterface = System.Net.NetworkInformation.NetworkInterface;
 using Task = System.Threading.Tasks.Task;
 
 namespace Brighid.Discord.Adapter.Management
@@ -26,6 +23,7 @@ namespace Brighid.Discord.Adapter.Management
         private readonly IAmazonECS ecs;
         private readonly IDnsService dns;
         private readonly AdapterOptions options;
+        private TaskMetadata? metadata;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NodeService" /> class.
@@ -48,39 +46,37 @@ namespace Brighid.Discord.Adapter.Management
         }
 
         /// <inheritdoc />
-        public IPAddress GetIpAddress()
+        public async Task<IPAddress> GetIpAddress(CancellationToken cancellationToken)
         {
-            var query = from @interface in NetworkInterface.GetAllNetworkInterfaces()
-                        where @interface.NetworkInterfaceType == NetworkInterfaceType.Ethernet
-                        from ip in @interface.GetIPProperties().UnicastAddresses
-                        where ip.Address.AddressFamily == AddressFamily.InterNetwork && !ip.Address.ToString().StartsWith("169.254.")
-                        select ip.Address;
+            cancellationToken.ThrowIfCancellationRequested();
+            var taskMetadata = await GetTaskMetadata(cancellationToken);
 
-            return query.FirstOrDefault(IPAddress.None);
+            return taskMetadata == null
+                    ? IPAddress.None
+                    : IPAddress.Parse(taskMetadata.Networks[0].Ipv4Addresses[0]);
         }
 
         /// <inheritdoc />
         public async Task<string> GetDeploymentId(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (options.TaskMetadataUrl == null)
+            var taskMetadata = await GetTaskMetadata(cancellationToken);
+            if (taskMetadata == null)
             {
                 return "local";
             }
 
-            var taskMetadata = await httpClient.GetFromJsonAsync<TaskMetadata>(options.TaskMetadataUrl, cancellationToken: cancellationToken);
             var describeTasksRequest = new DescribeTasksRequest { Cluster = taskMetadata!.Cluster, Tasks = new() { taskMetadata!.TaskArn } };
             var describeTasksResponse = await ecs.DescribeTasksAsync(describeTasksRequest, cancellationToken);
             return describeTasksResponse.Tasks.First().StartedBy;
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<NodeInfo>> GetPeers(CancellationToken cancellationToken)
+        public async Task<IEnumerable<NodeInfo>> GetPeers(IPAddress currentIp, CancellationToken cancellationToken)
         {
-            var currentIpAddress = GetIpAddress();
             var addresses = await dns.GetIPAddresses(options.Host, cancellationToken);
             var nodes = from address in addresses
-                        where address != GetIpAddress()
+                        where address != currentIp
                         select httpClient.GetFromJsonAsync<NodeInfo>($"http://{address}/node", cancellationToken: cancellationToken);
 
             try
@@ -91,6 +87,17 @@ namespace Brighid.Discord.Adapter.Management
             {
                 return Array.Empty<NodeInfo>();
             }
+        }
+
+        private async Task<TaskMetadata?> GetTaskMetadata(CancellationToken cancellationToken)
+        {
+            if (options.TaskMetadataUrl == null)
+            {
+                return null;
+            }
+
+            metadata ??= await httpClient.GetFromJsonAsync<TaskMetadata>(options.TaskMetadataUrl, cancellationToken: cancellationToken);
+            return metadata;
         }
     }
 }

--- a/src/Adapter/Management/Services/Node/NodeService.cs
+++ b/src/Adapter/Management/Services/Node/NodeService.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Amazon.ECS;
 using Amazon.ECS.Model;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using HttpClient = System.Net.Http.HttpClient;
@@ -22,6 +23,7 @@ namespace Brighid.Discord.Adapter.Management
         private readonly HttpClient httpClient;
         private readonly IAmazonECS ecs;
         private readonly IDnsService dns;
+        private readonly ILogger<NodeService> logger;
         private readonly AdapterOptions options;
         private TaskMetadata? metadata;
 
@@ -32,16 +34,19 @@ namespace Brighid.Discord.Adapter.Management
         /// <param name="ecs">ECS Service to fetch task info from.</param>
         /// <param name="dns">DNS Service to fetch IP addresses with.</param>
         /// <param name="options">Adapter options.</param>
+        /// <param name="logger">Service used for logging messages.</param>
         public NodeService(
             HttpClient httpClient,
             IAmazonECS ecs,
             IDnsService dns,
-            IOptions<AdapterOptions> options
+            IOptions<AdapterOptions> options,
+            ILogger<NodeService> logger
         )
         {
             this.httpClient = httpClient;
             this.ecs = ecs;
             this.dns = dns;
+            this.logger = logger;
             this.options = options.Value;
         }
 
@@ -97,6 +102,7 @@ namespace Brighid.Discord.Adapter.Management
             }
 
             metadata ??= await httpClient.GetFromJsonAsync<TaskMetadata>(options.TaskMetadataUrl, cancellationToken: cancellationToken);
+            logger.LogInformation("Retrieved task metadata {@metadata}", metadata);
             return metadata;
         }
     }

--- a/src/Adapter/Management/Services/Node/NodeService.cs
+++ b/src/Adapter/Management/Services/Node/NodeService.cs
@@ -81,7 +81,7 @@ namespace Brighid.Discord.Adapter.Management
         {
             var addresses = await dns.GetIPAddresses(options.Host, cancellationToken);
             var nodes = from address in addresses
-                        where address != currentIp
+                        where !address.Equals(currentIp)
                         select httpClient.GetFromJsonAsync<NodeInfo>($"http://{address}/node", cancellationToken: cancellationToken);
 
             try

--- a/src/Adapter/Management/Services/TrafficShifter/ITrafficShifter.cs
+++ b/src/Adapter/Management/Services/TrafficShifter/ITrafficShifter.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Brighid.Discord.Adapter.Management
+{
+    /// <summary>
+    /// Service used for shifting traffic.
+    /// </summary>
+    public interface ITrafficShifter
+    {
+        /// <summary>
+        /// Performs a traffic shift.
+        /// </summary>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The resulting task.</returns>
+        Task PerformTrafficShift(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Adapter/Management/Services/TrafficShifter/TrafficShifter.cs
+++ b/src/Adapter/Management/Services/TrafficShifter/TrafficShifter.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Brighid.Discord.Adapter.Gateway;
+
+using Microsoft.Extensions.Logging;
+
+namespace Brighid.Discord.Adapter.Management
+{
+    /// <inheritdoc />
+    public class TrafficShifter : ITrafficShifter
+    {
+        private readonly IAdapterContext context;
+        private readonly HttpClient httpClient;
+        private readonly ILogger<TrafficShifter> logger;
+        private readonly StringContent content = new(GatewayState.Stopped.ToString());
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TrafficShifter"/> class.
+        /// </summary>
+        /// <param name="context">Adapter context.</param>
+        /// <param name="httpClient">Client used for making HTTP calls for traffic shifting.</param>
+        /// <param name="logger">Service used for logging messages.</param>
+        public TrafficShifter(
+            IAdapterContext context,
+            HttpClient httpClient,
+            ILogger<TrafficShifter> logger
+        )
+        {
+            this.context = context;
+            this.httpClient = httpClient;
+            this.logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public async Task PerformTrafficShift(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var currentNode = context.Get<NodeInfo>();
+            var peers = context.Get<IEnumerable<NodeInfo>>();
+
+            var tasks = from peer in peers
+                        where peer.Shard == currentNode.Shard
+                        select Stop(peer.IpAddress, cancellationToken);
+
+            await Task.WhenAll(tasks);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private async Task Stop(IPAddress address, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var response = await httpClient.PutAsync($"http://{address}/node/gateway/state", content, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogError("Was unable to shift traffic from {@address}, got status code: {@status}", address, response.StatusCode);
+                return;
+            }
+
+            logger.LogInformation("Successfully shifted traffic from {@address}", address);
+        }
+    }
+}

--- a/src/Adapter/Management/Utils/ManagementServiceCollectionExtensions.cs
+++ b/src/Adapter/Management/Utils/ManagementServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<INodeService, NodeService>();
             services.AddSingleton<IAdapterContext, AdapterContext>();
             services.AddSingleton<IDnsService, DnsService>();
+            services.UseBrighidIdentityWithHttp2<ITrafficShifter, TrafficShifter>();
         }
     }
 }

--- a/src/Adapter/Program.cs
+++ b/src/Adapter/Program.cs
@@ -69,15 +69,16 @@ namespace Brighid.Discord.Adapter
             cancellationToken.ThrowIfCancellationRequested();
             var nodeService = host.Services.GetRequiredService<INodeService>();
             var adapterContext = host.Services.GetRequiredService<IAdapterContext>();
+            var ipAddress = await nodeService.GetIpAddress(cancellationToken);
 
             adapterContext.Set(new NodeInfo
             {
-                IpAddress = nodeService.GetIpAddress(),
+                IpAddress = ipAddress,
                 Shard = 0,
                 DeploymentId = await nodeService.GetDeploymentId(cancellationToken),
             });
 
-            var peers = await nodeService.GetPeers(cancellationToken);
+            var peers = await nodeService.GetPeers(ipAddress, cancellationToken);
             adapterContext.Set(peers);
         }
     }

--- a/src/Adapter/Program.cs
+++ b/src/Adapter/Program.cs
@@ -78,7 +78,6 @@ namespace Brighid.Discord.Adapter
                 DeploymentId = await nodeService.GetDeploymentId(cancellationToken),
             });
 
-            Console.WriteLine(ipAddress.ToString());
             var peers = await nodeService.GetPeers(ipAddress, cancellationToken);
             adapterContext.Set(peers);
         }

--- a/src/Adapter/Program.cs
+++ b/src/Adapter/Program.cs
@@ -78,6 +78,7 @@ namespace Brighid.Discord.Adapter
                 DeploymentId = await nodeService.GetDeploymentId(cancellationToken),
             });
 
+            Console.WriteLine(ipAddress.ToString());
             var peers = await nodeService.GetPeers(ipAddress, cancellationToken);
             adapterContext.Set(peers);
         }

--- a/src/Adapter/packages.lock.json
+++ b/src/Adapter/packages.lock.json
@@ -46,9 +46,9 @@
       },
       "Brighid.Identity.Client": {
         "type": "Direct",
-        "requested": "[0.6.2, )",
-        "resolved": "0.6.2",
-        "contentHash": "Czxs0EhOQ0ZAbdLVjvgm4P97eM0PSFxFjgiMKr7JvlBZ7PZ5xctuT+nbEmpDjl84/5nGRC0seZBTdwTjVb23yQ==",
+        "requested": "[0.6.3, )",
+        "resolved": "0.6.3",
+        "contentHash": "fL181rgJdBL5ZS7iiL7aDVWvQGWBK0AgI60kPM7AdVYcAr7yJD6IOeY+DyRy4/VcZveDea9lvwetEsiuhXLaTA==",
         "dependencies": {
           "Microsoft.Extensions.Caching.Memory": "6.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/src/Core/Tracing/Extensions/TracingServiceCollectionExtensions.cs
+++ b/src/Core/Tracing/Extensions/TracingServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Brighid.Discord.Tracing
         {
             AWSXRayRecorder.InitializeInstance();
 
-            services.AddSingleton<DelegatingHandler, HttpClientXRayTracingHandler>();
+            services.AddTransient<DelegatingHandler, HttpClientXRayTracingHandler>();
             services.TryAddSingleton<ITracingService, AwsXRayTracingService>();
             services.TryAddSingleton<ITracingIdService, AwsXRayTracingIdService>();
             services.TryAddSingleton<IAWSXRayRecorder>(AWSXRayRecorder.Instance);

--- a/tests/Adapter/Events/Controllers/MessageCreateEventControllerTests.cs
+++ b/tests/Adapter/Events/Controllers/MessageCreateEventControllerTests.cs
@@ -54,6 +54,22 @@ namespace Brighid.Discord.Adapter.Events
             }
 
             [Test, Auto]
+            public async Task ShouldThrowIfGatewayIsNotReady(
+                string content,
+                [Frozen, Substitute] IGatewayService gateway,
+                [Target] MessageCreateEventController controller
+            )
+            {
+                var cancellationToken = new CancellationToken(false);
+                var message = new Message { Content = content };
+                var @event = new MessageCreateEvent { Message = message };
+
+                await controller.Handle(@event, cancellationToken);
+
+                gateway.Received().ThrowIfNotReady();
+            }
+
+            [Test, Auto]
             public async Task ShouldStartAndStopATraceWithMessageAndEventAnnotations(
                 string content,
                 Snowflake userId,

--- a/tests/Adapter/Gateway/Services/DefaultGatewayServiceTests.cs
+++ b/tests/Adapter/Gateway/Services/DefaultGatewayServiceTests.cs
@@ -54,6 +54,31 @@ namespace Brighid.Discord.Adapter.Gateway
 
         [TestFixture]
         [Category("Unit")]
+        public class ThrowIfNotReadyTests
+        {
+            [Test, Auto]
+            public void ShouldThrowCanceledIfNotReady(
+                [Target] DefaultGatewayService service
+            )
+            {
+                service.SetPrivateProperty("State", GatewayState.Running);
+                Action func = service.ThrowIfNotReady;
+                func.Should().Throw<OperationCanceledException>();
+            }
+
+            [Test, Auto]
+            public void ShouldNotThrowCanceledIfReady(
+                [Target] DefaultGatewayService service
+            )
+            {
+                service.SetPrivateProperty("State", GatewayState.Running | GatewayState.Ready);
+                Action func = service.ThrowIfNotReady;
+                func.Should().NotThrow<OperationCanceledException>();
+            }
+        }
+
+        [TestFixture]
+        [Category("Unit")]
         public class StartTests
         {
             [Test, Auto]

--- a/tests/Adapter/Management/Services/NodeServiceTests.cs
+++ b/tests/Adapter/Management/Services/NodeServiceTests.cs
@@ -41,7 +41,7 @@ namespace Brighid.Discord.Adapter.Management
             {
                 handler
                 .Expect(HttpMethod.Get, options.TaskMetadataUrl!.ToString())
-                .Respond("application/json", $@"{{ ""Networks"": [ {{ ""IPv4Addresses"": [ ""{ip}"" ] }} ] }}");
+                .Respond("application/json", $@"{{ ""Containers"": [ {{ ""Networks"": [ {{ ""IPv4Addresses"": [ ""{ip}"" ] }} ] }} ] }}");
 
                 var result = await service.GetIpAddress(cancellationToken);
 

--- a/tests/Adapter/Management/Services/TrafficShifterTests.cs
+++ b/tests/Adapter/Management/Services/TrafficShifterTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using AutoFixture.NUnit3;
+
+using FluentAssertions;
+
+using NSubstitute;
+
+using NUnit.Framework;
+
+using RichardSzalay.MockHttp;
+
+namespace Brighid.Discord.Adapter.Management
+{
+    public class TrafficShifterTests
+    {
+        [TestFixture]
+        [Category("Unit")]
+        public class PerformTrafficShiftTests
+        {
+            public static void SetupNode(NodeInfo node, int shard, string ip, MockHttpMessageHandler http, bool expected)
+            {
+                node.Shard = shard;
+                node.IpAddress = IPAddress.Parse(ip);
+
+                if (expected)
+                {
+                    http
+                    .Expect(HttpMethod.Put, $"http://{ip}/node/gateway/state")
+                    .Respond(HttpStatusCode.NoContent);
+                }
+            }
+
+            [Test, Auto]
+            public async Task ShouldStopGatewayForPeersWithTheSameShard(
+                NodeInfo currentNode,
+                NodeInfo peer1,
+                NodeInfo peer2,
+                NodeInfo peer3,
+                [Frozen] MockHttpMessageHandler http,
+                [Frozen] IAdapterContext context,
+                [Target] TrafficShifter shifter,
+                CancellationToken cancellationToken
+            )
+            {
+                currentNode.Shard = 2;
+                SetupNode(peer1, 2, "1.1.1.1", http, true);
+                SetupNode(peer2, 1, "2.2.2.2", http, false);
+                SetupNode(peer3, 2, "3.3.3.3", http, true);
+
+                context.Get<NodeInfo>().Returns(currentNode);
+                context.Get<IEnumerable<NodeInfo>>().Returns(new[] { peer1, peer2, peer3 });
+
+                await shifter.PerformTrafficShift(cancellationToken);
+
+                http.VerifyNoOutstandingExpectation();
+            }
+
+            [Test, Auto]
+            public async Task ShouldHandleErrorsGracefully(
+                NodeInfo currentNode,
+                NodeInfo peer1,
+                NodeInfo peer2,
+                NodeInfo peer3,
+                [Frozen] MockHttpMessageHandler http,
+                [Frozen] IAdapterContext context,
+                [Target] TrafficShifter shifter,
+                CancellationToken cancellationToken
+            )
+            {
+                currentNode.Shard = 2;
+                SetupNode(peer1, 2, "1.1.1.1", http, true);
+                SetupNode(peer2, 1, "2.2.2.2", http, false);
+                SetupNode(peer3, 2, "3.3.3.3", http, false);
+
+                context.Get<NodeInfo>().Returns(currentNode);
+                context.Get<IEnumerable<NodeInfo>>().Returns(new[] { peer1, peer2, peer3 });
+
+                Func<Task> func = () => shifter.PerformTrafficShift(cancellationToken);
+
+                await func.Should().NotThrowAsync();
+            }
+        }
+    }
+}

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -288,8 +288,8 @@
       },
       "Brighid.Identity.Client": {
         "type": "Transitive",
-        "resolved": "0.6.2",
-        "contentHash": "Czxs0EhOQ0ZAbdLVjvgm4P97eM0PSFxFjgiMKr7JvlBZ7PZ5xctuT+nbEmpDjl84/5nGRC0seZBTdwTjVb23yQ==",
+        "resolved": "0.6.3",
+        "contentHash": "fL181rgJdBL5ZS7iiL7aDVWvQGWBK0AgI60kPM7AdVYcAr7yJD6IOeY+DyRy4/VcZveDea9lvwetEsiuhXLaTA==",
         "dependencies": {
           "Microsoft.Extensions.Caching.Memory": "6.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -2671,7 +2671,7 @@
           "AWSSDK.SimpleNotificationService": "3.7.3.77",
           "Brighid.Commands.Client": "0.2.0",
           "Brighid.Discord.Core": "1.0.0",
-          "Brighid.Identity.Client": "0.6.2",
+          "Brighid.Identity.Client": "0.6.3",
           "Destructurama.Attributed": "3.0.0",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "6.0.6",
           "Microsoft.EntityFrameworkCore": "6.0.6",


### PR DESCRIPTION
Performs a traffic shift for gateway traffic from previous nodes with the same shard ID as the current one when the task starts up.