### PR TITLE
Experiment: Use Thread.Sleep For Accurate Delay

### DIFF
--- a/src/Core/Threading/Services/Timer.cs
+++ b/src/Core/Threading/Services/Timer.cs
@@ -88,7 +88,7 @@ namespace Brighid.Discord.Threading
                 {
                     if (period > 0)
                     {
-                        await Task.Delay(period, cancellationToken);
+                        Thread.Sleep(period);
                     }
 
                     await callback(cancellationToken);


### PR DESCRIPTION
Attempting to use thread.sleep for a more accurate delay.  Hoping to reduce gateway drops/reconnects