### PR TITLE
BRGD-280 API Version Pinning

### DIFF
--- a/src/Adapter/AdapterOptions.cs
+++ b/src/Adapter/AdapterOptions.cs
@@ -36,6 +36,11 @@ namespace Brighid.Discord.Adapter
         public string Host { get; set; } = "discord.brigh.id";
 
         /// <summary>
+        /// Gets or sets the discord api version to use.
+        /// </summary>
+        public string ApiVersion { get; set; } = "v10";
+
+        /// <summary>
         /// Gets or sets the token to authenticate against the gateway and REST API with.
         /// </summary>
         [NotLogged]
@@ -63,14 +68,9 @@ namespace Brighid.Discord.Adapter
         public string StaticAssetsRepositoryUrl { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the OAuth2 User Info Endpoint.
+        /// Gets or sets the Discord API Base URL.
         /// </summary>
-        public Uri OAuth2UserInfoEndpoint { get; set; } = new Uri("https://discord.com/api/users/@me");
-
-        /// <summary>
-        /// Gets or sets the Discord OAuth2 Token Endpoint.
-        /// </summary>
-        public Uri OAuth2TokenEndpoint { get; set; } = new Uri("https://discord.com/api/oauth2/token");
+        public Uri DiscordApiBaseUrl { get; set; } = new Uri("https://discord.com/api/");
 
         /// <summary>
         /// Gets or sets the Redirect URI used for Discord OAuth2.

--- a/src/Adapter/Management/Services/DiscordApiInfo/DiscordApiInfoService.cs
+++ b/src/Adapter/Management/Services/DiscordApiInfo/DiscordApiInfoService.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Runtime.CompilerServices;
+
+using Microsoft.Extensions.Options;
+
+namespace Brighid.Discord.Adapter.Management
+{
+    /// <inheritdoc />
+    public class DiscordApiInfoService : IDiscordApiInfoService
+    {
+        private readonly AdapterOptions adapterOptions;
+        private Uri? apiBaseUrl;
+        private Uri? oauth2TokenEndpoint;
+        private Uri? oauth2UserInfoEndpoint;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DiscordApiInfoService" /> class.
+        /// </summary>
+        /// <param name="adapterOptions">Options to use for the adapter.</param>
+        public DiscordApiInfoService(
+            IOptions<AdapterOptions> adapterOptions
+        )
+        {
+            this.adapterOptions = adapterOptions.Value;
+        }
+
+        /// <inheritdoc />
+        public string ClientId => adapterOptions.ClientId;
+
+        /// <inheritdoc />
+        public string ClientSecret => adapterOptions.ClientSecret;
+
+        /// <inheritdoc />
+        public Uri ApiBaseUrl => apiBaseUrl ??= CombineUris(adapterOptions.DiscordApiBaseUrl, adapterOptions.ApiVersion);
+
+        /// <inheritdoc />
+        public Uri OAuth2TokenEndpoint => oauth2TokenEndpoint ??= CombineUris(ApiBaseUrl, "/oauth2/token");
+
+        /// <inheritdoc />
+        public Uri OAuth2UserInfoEndpoint => oauth2UserInfoEndpoint ??= CombineUris(ApiBaseUrl, "/users/@me");
+
+        /// <inheritdoc />
+        public Uri OAuth2RedirectUri => adapterOptions.OAuth2RedirectUri;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Uri CombineUris(Uri baseUri, string relative)
+        {
+            var baseUrl = baseUri.ToString().TrimEnd('/');
+            return new Uri(baseUrl + $"/{relative.TrimStart('/')}");
+        }
+    }
+}

--- a/src/Adapter/Management/Services/DiscordApiInfo/IDiscordApiInfoService.cs
+++ b/src/Adapter/Management/Services/DiscordApiInfo/IDiscordApiInfoService.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Brighid.Discord.Adapter.Management
+{
+    /// <summary>
+    /// Service for getting info about the discord API.
+    /// </summary>
+    public interface IDiscordApiInfoService
+    {
+        /// <summary>
+        /// Gets the client id used to authenticate with the discord API.
+        /// </summary>
+        string ClientId { get; }
+
+        /// <summary>
+        /// Gets the client secret used to authenticate with the discord API.
+        /// </summary>
+        string ClientSecret { get; }
+
+        /// <summary>
+        /// Gets the base API URL to use for interacting with the discord API.
+        /// </summary>
+        Uri ApiBaseUrl { get; }
+
+        /// <summary>
+        /// Gets the OAuth2 Token endpoint for authenticating with the discord API.
+        /// </summary>
+        Uri OAuth2TokenEndpoint { get; }
+
+        /// <summary>
+        /// Gets the OAuth2 User Info endpoint for authenticating with the discord API.
+        /// </summary>
+        Uri OAuth2UserInfoEndpoint { get; }
+
+        /// <summary>
+        /// Gets the OAuth2 Redirect URI endpoint for authenticating with the discord API.
+        /// </summary>
+        Uri OAuth2RedirectUri { get; }
+    }
+}

--- a/src/Adapter/Management/Utils/ManagementServiceCollectionExtensions.cs
+++ b/src/Adapter/Management/Utils/ManagementServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IAdapterContext, AdapterContext>();
             services.AddSingleton<IDnsService, DnsService>();
             services.AddSingleton<INodeService, NodeService>();
+            services.AddSingleton<IDiscordApiInfoService, DiscordApiInfoService>();
             services.UseBrighidIdentityWithHttp2<ITrafficShifter, TrafficShifter>();
         }
     }

--- a/src/Adapter/Requests/Models/RequestOptions.cs
+++ b/src/Adapter/Requests/Models/RequestOptions.cs
@@ -33,10 +33,5 @@ namespace Brighid.Discord.Adapter.Requests
         /// Gets or sets the maximum amount of messages than can be received from SQS at once.
         /// </summary>
         public uint MessageBufferSize { get; set; } = 10;
-
-        /// <summary>
-        /// Gets or sets the base URL used for invoking requests.
-        /// </summary>
-        public Uri InvokeBaseUrl { get; set; } = new Uri("https://discord.com/api");
     }
 }

--- a/src/Adapter/Requests/Services/DefaultUrlBuilder.cs
+++ b/src/Adapter/Requests/Services/DefaultUrlBuilder.cs
@@ -1,25 +1,24 @@
 using System;
 
+using Brighid.Discord.Adapter.Management;
 using Brighid.Discord.Models;
-
-using Microsoft.Extensions.Options;
 
 namespace Brighid.Discord.Adapter.Requests
 {
     /// <inheritdoc />
     public class DefaultUrlBuilder : IUrlBuilder
     {
-        private readonly RequestOptions options;
+        private readonly IDiscordApiInfoService discordApiInfoService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultUrlBuilder" /> class.
         /// </summary>
-        /// <param name="options">Options to use when making requests.</param>
+        /// <param name="discordApiInfoService">Discord API Info Service.</param>
         public DefaultUrlBuilder(
-            IOptions<RequestOptions> options
+            IDiscordApiInfoService discordApiInfoService
         )
         {
-            this.options = options.Value;
+            this.discordApiInfoService = discordApiInfoService;
         }
 
         /// <inheritdoc />
@@ -47,10 +46,10 @@ namespace Brighid.Discord.Adapter.Requests
                     : $"/{part}";
             }
 
-            return new Uri(options.InvokeBaseUrl + result);
+            return new Uri(discordApiInfoService.ApiBaseUrl + result);
         }
 
-        private bool IsParameter(string value, out string name)
+        private static bool IsParameter(string value, out string name)
         {
             var result = value.StartsWith('{') && value.EndsWith('}');
             name = result ? value.TrimStart('{').TrimEnd('}') : string.Empty;

--- a/tests/Adapter/Management/Services/DiscordApiInfoServiceTests.cs
+++ b/tests/Adapter/Management/Services/DiscordApiInfoServiceTests.cs
@@ -1,0 +1,87 @@
+using System;
+
+using AutoFixture.NUnit3;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+namespace Brighid.Discord.Adapter.Management
+{
+    [TestFixture]
+    [Category("Unit")]
+    public class DiscordApiInfoServiceTests
+    {
+        [Test, Auto]
+        public void ClientIdShouldReturnClientId(
+            string clientId,
+            [Frozen] AdapterOptions options,
+            [Target] DiscordApiInfoService service
+        )
+        {
+            options.ClientId = clientId;
+
+            service.ClientId.Should().Be(clientId);
+        }
+
+        [Test, Auto]
+        public void ClientSecretShouldReturnClientSecret(
+            string clientSecret,
+            [Frozen] AdapterOptions options,
+            [Target] DiscordApiInfoService service
+        )
+        {
+            options.ClientSecret = clientSecret;
+
+            service.ClientSecret.Should().Be(clientSecret);
+        }
+
+        [Test, Auto]
+        public void ApiBaseUrlShouldReturnBaseUrlWithVersion(
+            string apiVersion,
+            [Frozen] AdapterOptions options,
+            [Target] DiscordApiInfoService service
+        )
+        {
+            options.DiscordApiBaseUrl = new Uri("https://discord.com/api");
+            options.ApiVersion = apiVersion;
+
+            service.ApiBaseUrl.Should().Be($"https://discord.com/api/{apiVersion}");
+        }
+
+        [Test, Auto]
+        public void OAuth2TokenEndpointShouldReturnFullyQualifiedTokenEndpoint(
+            string apiVersion,
+            [Frozen] AdapterOptions options,
+            [Target] DiscordApiInfoService service
+        )
+        {
+            options.DiscordApiBaseUrl = new Uri("https://discord.com/api");
+            options.ApiVersion = apiVersion;
+
+            service.OAuth2TokenEndpoint.Should().Be($"https://discord.com/api/{apiVersion}/oauth2/token");
+        }
+
+        [Test, Auto]
+        public void OAuth2UserInfoEndpointShouldReturnFullyQualifiedUserInfoEndpoint(
+            string apiVersion,
+            [Frozen] AdapterOptions options,
+            [Target] DiscordApiInfoService service
+        )
+        {
+            options.DiscordApiBaseUrl = new Uri("https://discord.com/api");
+            options.ApiVersion = apiVersion;
+
+            service.OAuth2UserInfoEndpoint.Should().Be($"https://discord.com/api/{apiVersion}/users/@me");
+        }
+
+        [Test, Auto]
+        public void Oauth2RedirectUriShouldReturnOauth2RedirectUri(
+            [Frozen] AdapterOptions options,
+            [Target] DiscordApiInfoService service
+        )
+        {
+            service.OAuth2RedirectUri.Should().Be(options.OAuth2RedirectUri);
+        }
+    }
+}

--- a/tests/Adapter/Requests/Services/DefaultUrlBuilderTests.cs
+++ b/tests/Adapter/Requests/Services/DefaultUrlBuilderTests.cs
@@ -2,6 +2,7 @@ using System;
 
 using AutoFixture.NUnit3;
 
+using Brighid.Discord.Adapter.Management;
 using Brighid.Discord.Models;
 
 using FluentAssertions;
@@ -36,6 +37,7 @@ namespace Brighid.Discord.Adapter.Requests
                 Request request,
                 Uri baseUrl,
                 [Frozen] RequestOptions options,
+                [Frozen] IDiscordApiInfoService discordApiInfoService,
                 [Target] DefaultUrlBuilder builder
             )
             {
@@ -43,7 +45,7 @@ namespace Brighid.Discord.Adapter.Requests
                 request.Parameters["channel.id"] = channelId;
 
                 var result = builder.BuildFromRequest(request);
-                result.Should().Be($"{options.InvokeBaseUrl}/channels/{channelId}/messages");
+                result.Should().Be($"{discordApiInfoService.ApiBaseUrl}/channels/{channelId}/messages");
             }
 
             [Test, Auto]

--- a/tests/Adapter/Users/Services/DefaultUserServiceTests.cs
+++ b/tests/Adapter/Users/Services/DefaultUserServiceTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.NUnit3;
 
+using Brighid.Discord.Adapter.Management;
 using Brighid.Discord.Models;
 using Brighid.Identity.Client;
 
@@ -32,14 +33,14 @@ namespace Brighid.Discord.Adapter.Users
             public async Task ShouldMakeARequestToDiscordsTokenEndpointWithTheCode(
                 string code,
                 string accessToken,
-                [Frozen] AdapterOptions adapterOptions,
+                [Frozen] IDiscordApiInfoService discordApiInfo,
                 [Frozen] MockHttpMessageHandler handler,
                 [Target] DefaultUserService service,
                 CancellationToken cancellationToken
             )
             {
                 handler
-                .Expect(HttpMethod.Post, adapterOptions.OAuth2TokenEndpoint.ToString())
+                .Expect(HttpMethod.Post, discordApiInfo.OAuth2TokenEndpoint.ToString())
                 .WithFormData("code", code)
                 .Respond("application/json", @$"{{""access_token"":""{accessToken}""}}");
 
@@ -52,15 +53,15 @@ namespace Brighid.Discord.Adapter.Users
             public async Task ShouldMakeARequestToDiscordsTokenEndpointWithTheClientId(
                 string code,
                 string accessToken,
-                [Frozen] AdapterOptions adapterOptions,
+                [Frozen] IDiscordApiInfoService discordApiInfo,
                 [Frozen] MockHttpMessageHandler handler,
                 [Target] DefaultUserService service,
                 CancellationToken cancellationToken
             )
             {
                 handler
-                .Expect(HttpMethod.Post, adapterOptions.OAuth2TokenEndpoint.ToString())
-                .WithFormData("client_id", adapterOptions.ClientId)
+                .Expect(HttpMethod.Post, discordApiInfo.OAuth2TokenEndpoint.ToString())
+                .WithFormData("client_id", discordApiInfo.ClientId)
                 .Respond("application/json", @$"{{""access_token"":""{accessToken}""}}");
 
                 await service.ExchangeOAuth2CodeForToken(code, cancellationToken);
@@ -72,15 +73,15 @@ namespace Brighid.Discord.Adapter.Users
             public async Task ShouldMakeARequestToDiscordsTokenEndpointWithTheClientSecret(
                 string code,
                 string accessToken,
-                [Frozen] AdapterOptions adapterOptions,
+                [Frozen] IDiscordApiInfoService discordApiInfo,
                 [Frozen] MockHttpMessageHandler handler,
                 [Target] DefaultUserService service,
                 CancellationToken cancellationToken
             )
             {
                 handler
-                .Expect(HttpMethod.Post, adapterOptions.OAuth2TokenEndpoint.ToString())
-                .WithFormData("client_secret", adapterOptions.ClientSecret)
+                .Expect(HttpMethod.Post, discordApiInfo.OAuth2TokenEndpoint.ToString())
+                .WithFormData("client_secret", discordApiInfo.ClientSecret)
                 .Respond("application/json", @$"{{""access_token"":""{accessToken}""}}");
 
                 await service.ExchangeOAuth2CodeForToken(code, cancellationToken);
@@ -92,14 +93,14 @@ namespace Brighid.Discord.Adapter.Users
             public async Task ShouldMakeARequestToDiscordsTokenEndpointWithTheGrantType(
                 string code,
                 string accessToken,
-                [Frozen] AdapterOptions adapterOptions,
+                [Frozen] IDiscordApiInfoService discordApiInfo,
                 [Frozen] MockHttpMessageHandler handler,
                 [Target] DefaultUserService service,
                 CancellationToken cancellationToken
             )
             {
                 handler
-                .Expect(HttpMethod.Post, adapterOptions.OAuth2TokenEndpoint.ToString())
+                .Expect(HttpMethod.Post, discordApiInfo.OAuth2TokenEndpoint.ToString())
                 .WithFormData("grant_type", "authorization_code")
                 .Respond("application/json", @$"{{""access_token"":""{accessToken}""}}");
 
@@ -112,15 +113,15 @@ namespace Brighid.Discord.Adapter.Users
             public async Task ShouldMakeARequestToDiscordsTokenEndpointWithTheRedirectUri(
                 string code,
                 string accessToken,
-                [Frozen] AdapterOptions adapterOptions,
+                [Frozen] IDiscordApiInfoService discordApiInfo,
                 [Frozen] MockHttpMessageHandler handler,
                 [Target] DefaultUserService service,
                 CancellationToken cancellationToken
             )
             {
                 handler
-                .Expect(HttpMethod.Post, adapterOptions.OAuth2TokenEndpoint.ToString())
-                .WithFormData("redirect_uri", adapterOptions.OAuth2RedirectUri.ToString())
+                .Expect(HttpMethod.Post, discordApiInfo.OAuth2TokenEndpoint.ToString())
+                .WithFormData("redirect_uri", discordApiInfo.OAuth2RedirectUri.ToString())
                 .Respond("application/json", @$"{{""access_token"":""{accessToken}""}}");
 
                 await service.ExchangeOAuth2CodeForToken(code, cancellationToken);
@@ -132,14 +133,14 @@ namespace Brighid.Discord.Adapter.Users
             public async Task ShouldReturnTheAccessTokenFromTheBody(
                 string code,
                 string accessToken,
-                [Frozen] AdapterOptions adapterOptions,
+                [Frozen] IDiscordApiInfoService discordApiInfo,
                 [Frozen] MockHttpMessageHandler handler,
                 [Target] DefaultUserService service,
                 CancellationToken cancellationToken
             )
             {
                 handler
-                .Expect(HttpMethod.Post, adapterOptions.OAuth2TokenEndpoint.ToString())
+                .Expect(HttpMethod.Post, discordApiInfo.OAuth2TokenEndpoint.ToString())
                 .Respond("application/json", @$"{{""access_token"":""{accessToken}""}}");
 
                 var result = await service.ExchangeOAuth2CodeForToken(code, cancellationToken);
@@ -156,14 +157,14 @@ namespace Brighid.Discord.Adapter.Users
             public async Task ShouldSendARequestToTheMeEndpointAndReturnTheUserId(
                 Snowflake userId,
                 string token,
-                [Frozen] AdapterOptions adapterOptions,
+                [Frozen] IDiscordApiInfoService discordApiInfo,
                 [Frozen] MockHttpMessageHandler handler,
                 [Target] DefaultUserService service,
                 CancellationToken cancellationToken
             )
             {
                 handler
-                .Expect(HttpMethod.Get, adapterOptions.OAuth2UserInfoEndpoint.ToString())
+                .Expect(HttpMethod.Get, discordApiInfo.OAuth2UserInfoEndpoint.ToString())
                 .WithHeaders("authorization", $"Bearer {token}")
                 .Respond("application/json", $@"{{""id"":""{userId.Value}""}}");
 


### PR DESCRIPTION
Now using a pinned API version when interacting with the discord API instead of using the default, which is an extremely outdated version of it.